### PR TITLE
Compute expansion fix

### DIFF
--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -1460,6 +1460,9 @@ class OptimizationDataset(BasicDataset):
         if verbose:
             print(f"Number of new entries: {new_entries}/{self.n_records}")
         collection.save()
+        # if we have no new indices grab them all from the dataset
+        if not indices:
+            indices = list(collection.df.index)
 
         responses = {}
         chunk_size = 100
@@ -1698,6 +1701,10 @@ class TorsiondriveDataset(OptimizationDataset):
         if verbose:
             print(f"Number of new entries: {new_entries}/{self.n_records}")
         collection.save()
+
+        # if there are no new tasks, generate them for all entries
+        if not indices:
+            indices = list(collection.df.index)
 
         responses = {}
         chunk_size = 100


### PR DESCRIPTION
## Description
This is a temporary fix for #93. If no new entries are added to a dataset in qcarchive qcsubmit will now try and generate tasks for all entries present in the dataset,  tests added for optimization and torsiondrive datasets, normal dataset submission works slightly differently.

## Status
- [X] Ready to go