### PR TITLE
Create CMILES object directly from a molecule

### DIFF
--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -1038,6 +1038,52 @@ class MoleculeAttributes(DatasetConfig):
         ..., description="The standard inchi key given by the inchi program."
     )
 
+    @classmethod
+    def from_openff_molecule(cls, molecule) -> "MoleculeAttributes":
+        """Create the Cmiles metadata for an OpenFF molecule object.
+
+        Parameters:
+            molecule: The molecule for which the cmiles data will be generated.
+
+        Returns:
+            The Cmiles identifiers generated for the input molecule.
+
+        Note:
+            The Cmiles identifiers currently include:
+
+            - `canonical_smiles`
+            - `canonical_isomeric_smiles`
+            - `canonical_explicit_hydrogen_smiles`
+            - `canonical_isomeric_explicit_hydrogen_smiles`
+            - `canonical_isomeric_explicit_hydrogen_mapped_smiles`
+            - `molecular_formula`
+            - `standard_inchi`
+            - `inchi_key`
+        """
+
+        cmiles = {
+            "canonical_smiles": molecule.to_smiles(
+                isomeric=False, explicit_hydrogens=False, mapped=False
+            ),
+            "canonical_isomeric_smiles": molecule.to_smiles(
+                isomeric=True, explicit_hydrogens=False, mapped=False
+            ),
+            "canonical_explicit_hydrogen_smiles": molecule.to_smiles(
+                isomeric=False, explicit_hydrogens=True, mapped=False
+            ),
+            "canonical_isomeric_explicit_hydrogen_smiles": molecule.to_smiles(
+                isomeric=True, explicit_hydrogens=True, mapped=False
+            ),
+            "canonical_isomeric_explicit_hydrogen_mapped_smiles": molecule.to_smiles(
+                isomeric=True, explicit_hydrogens=True, mapped=True
+            ),
+            "molecular_formula": molecule.hill_formula,
+            "standard_inchi": molecule.to_inchi(fixed_hydrogens=False),
+            "inchi_key": molecule.to_inchikey(fixed_hydrogens=False),
+        }
+
+        return MoleculeAttributes(**cmiles)
+
 
 class SCFProperties(str, Enum):
     """

--- a/openff/qcsubmit/factories.py
+++ b/openff/qcsubmit/factories.py
@@ -551,28 +551,7 @@ class BasicDatasetFactory(CommonBase):
             - `inchi_key`
         """
 
-        cmiles = {
-            "canonical_smiles": molecule.to_smiles(
-                isomeric=False, explicit_hydrogens=False, mapped=False
-            ),
-            "canonical_isomeric_smiles": molecule.to_smiles(
-                isomeric=True, explicit_hydrogens=False, mapped=False
-            ),
-            "canonical_explicit_hydrogen_smiles": molecule.to_smiles(
-                isomeric=False, explicit_hydrogens=True, mapped=False
-            ),
-            "canonical_isomeric_explicit_hydrogen_smiles": molecule.to_smiles(
-                isomeric=True, explicit_hydrogens=True, mapped=False
-            ),
-            "canonical_isomeric_explicit_hydrogen_mapped_smiles": molecule.to_smiles(
-                isomeric=True, explicit_hydrogens=True, mapped=True
-            ),
-            "molecular_formula": molecule.hill_formula,
-            "standard_inchi": molecule.to_inchi(fixed_hydrogens=False),
-            "inchi_key": molecule.to_inchikey(fixed_hydrogens=False),
-        }
-
-        return MoleculeAttributes(**cmiles)
+        return MoleculeAttributes.from_openff_molecule(molecule)
 
     def create_index(self, molecule: off.Molecule) -> str:
         """

--- a/openff/qcsubmit/tests/test_common_structures.py
+++ b/openff/qcsubmit/tests/test_common_structures.py
@@ -1,0 +1,27 @@
+from openff.toolkit.topology import Molecule
+
+from openff.qcsubmit.common_structures import MoleculeAttributes
+
+
+def test_attributes_from_openff_molecule():
+
+    mol = Molecule.from_smiles("CC")
+
+    attributes = MoleculeAttributes.from_openff_molecule(mol)
+
+    # now make our own cmiles
+    test_cmiles = {
+        "canonical_smiles": mol.to_smiles(isomeric=False, explicit_hydrogens=False, mapped=False),
+        "canonical_isomeric_smiles": mol.to_smiles(isomeric=True, explicit_hydrogens=False, mapped=False),
+        "canonical_explicit_hydrogen_smiles": mol.to_smiles(isomeric=False, explicit_hydrogens=True, mapped=False),
+        "canonical_isomeric_explicit_hydrogen_smiles": mol.to_smiles(
+            isomeric=True, explicit_hydrogens=True, mapped=False
+        ),
+        "canonical_isomeric_explicit_hydrogen_mapped_smiles": mol.to_smiles(
+            isomeric=True, explicit_hydrogens=True, mapped=True
+        ),
+        "molecular_formula": mol.hill_formula,
+        "standard_inchi": mol.to_inchi(fixed_hydrogens=False),
+        "inchi_key": mol.to_inchikey(fixed_hydrogens=False),
+    }
+    assert test_cmiles == attributes


### PR DESCRIPTION
## Description

This PR adds a convenience method to create a CMILES containing `MoleculeAttributes` object from an OpenFF molecule. This allows the object to be created directly without first needing to create a dataset factory first.

## Questions
- [x] I named this method `from_openff_molecule` to make it explicit that this method creates from an OpenFF molecule rather than say a QCElemental molecule, but it may be better to just have a `from_molecule` method and handle the molecule type in the method itself, maybe making private `_from_openff_molecule`, `_from_qcel_molecule`, `_from_XXX_molecule` methods to handle the different molecule cases. 

## Status
- [ ] Ready to go