### PR TITLE
Ensure multiple conformers generated for `test_rmsd_filter`

### DIFF
--- a/openff/qcsubmit/tests/test_workflow_components.py
+++ b/openff/qcsubmit/tests/test_workflow_components.py
@@ -332,7 +332,7 @@ def test_rmsd_filter():
     rmsd_filter = workflow_components.RMSDCutoffConformerFilter(cutoff=1)
     mol = Molecule.from_smiles("CCCC")
     # make a lot of conformers for the molecule
-    mol.generate_conformers(n_conformers=1000, rms_cutoff=0.5 * unit.angstrom, toolkit_registry=RDKitToolkitWrapper())
+    mol.generate_conformers(n_conformers=1000, rms_cutoff=0.05 * unit.angstrom, toolkit_registry=RDKitToolkitWrapper())
     ref_mol = copy.deepcopy(mol)
     result = rmsd_filter.apply([mol, ], processors=1)
     # now make sure the number of conformers is different


### PR DESCRIPTION
## Description

This PR fixes the current test failures by ensuring that multiple conformers are generated as part of the setup for the `test_rmsd_filter` unit test. This test likely started failing due to changes made by the RDKit 2021.03.1 release (#3813 in particular?) which coincides with when the CRON CI started to fail.

## Status
- [X] Ready to go