### PR TITLE
Add initial result filter API

### DIFF
--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -1,0 +1,57 @@
+import abc
+import logging
+from typing import TYPE_CHECKING, TypeVar
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+
+    from openff.qcsubmit.results.results import _BaseResultCollection
+
+    T = TypeVar("T", bound=_BaseResultCollection)
+
+logger = logging.getLogger(__name__)
+
+
+class ResultFilter(BaseModel, abc.ABC):
+    """The base class for a filter which will retain selection of QC records based on
+    a specific criterion.
+    """
+
+    @abc.abstractmethod
+    def _apply(self, result_collection: "T") -> "T":
+        """The internal implementation of thr ``apply`` method which should apply this
+        filter to a results collection and return a new collection containing only the
+        retained entries.
+
+        Notes:
+            The ``result_collection`` passed to this function will be a copy and
+            so can be modified in place if needed.
+
+        Args:
+            result_collection: The collection to apply the filter to.
+
+        Returns:
+            The collection containing only the retained entries.
+        """
+        raise NotImplementedError()
+
+    def apply(self, result_collection: "T") -> "T":
+        """Apply this filter to a results collection, returning a new collection
+        containing only the retained entries.
+
+        Args:
+            result_collection: The collection to apply the filter to.
+
+        Returns:
+            The collection containing only the retained entries.
+        """
+
+        filtered_collection = self._apply(result_collection.copy(deep=True))
+
+        logger.info(
+            f"{abs(filtered_collection.n_results - result_collection.n_results)} "
+            f"results were removed after applying a {self.__class__.__name__} filter."
+        )
+
+        return filtered_collection

--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -54,4 +54,12 @@ class ResultFilter(BaseModel, abc.ABC):
             f"results were removed after applying a {self.__class__.__name__} filter."
         )
 
+        if "applied-filters" not in filtered_collection.provenance:
+            filtered_collection.provenance["applied-filters"] = {}
+
+        n_existing_filters = len(filtered_collection.provenance["applied-filters"])
+        filter_name = f"{self.__class__.__name__}-{n_existing_filters}"
+
+        filtered_collection.provenance["applied-filters"][filter_name] = {**self.dict()}
+
         return filtered_collection

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -4,7 +4,7 @@ results from a QCFractal instance.
 """
 import abc
 from collections import defaultdict
-from typing import Callable, Dict, Iterable, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Type, TypeVar, Union
 
 import qcportal
 from openff.toolkit.topology import Molecule
@@ -21,6 +21,7 @@ from typing_extensions import Literal
 from openff.qcsubmit.common_structures import Metadata
 from openff.qcsubmit.datasets import BasicDataset
 from openff.qcsubmit.exceptions import RecordTypeError
+from openff.qcsubmit.results.filters import ResultFilter
 
 T = TypeVar("T")
 S = TypeVar("S")
@@ -65,6 +66,12 @@ class _BaseResultCollection(BaseModel, abc.ABC):
         ...,
         description="The entries stored in this collection in a dictionary of the form "
         "``collection.entries['qcfractal_address'] = [record_1, ..., record_N]``.",
+    )
+
+    provenance: Dict[str, Any] = Field(
+        {},
+        description="A dictionary which can contain provenance information about "
+        "how and why this collection was curated.",
     )
 
     @validator("entries")
@@ -210,6 +217,34 @@ class _BaseResultCollection(BaseModel, abc.ABC):
             )
 
         return records
+
+    def filter(self, *filters: ResultFilter):
+        """Filter this collection by applying a set of filters sequentially, returning
+        a new collection containing only the retained entries.
+
+        Notes:
+            Information about any applied filters will be stored in the provenance
+            dictionary in the 'applied-filters' field. Any existing information in
+            this field will be overwritten here.
+
+        Args:
+            filters: The filters to apply, in the order to apply them in.
+
+        Returns:
+            The collection containing only the retained entries.
+        """
+
+        filtered_collection = self.copy(deep=True)
+
+        for collection_filter in filters:
+            filtered_collection = collection_filter.apply(filtered_collection)
+
+        filtered_collection.provenance["applied-filters"] = {
+            collection_filter.__class__.__name__: {**collection_filter.dict()}
+            for collection_filter in filters
+        }
+
+        return filtered_collection
 
 
 class BasicResult(_BaseResult):

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -239,11 +239,6 @@ class _BaseResultCollection(BaseModel, abc.ABC):
         for collection_filter in filters:
             filtered_collection = collection_filter.apply(filtered_collection)
 
-        filtered_collection.provenance["applied-filters"] = {
-            collection_filter.__class__.__name__: {**collection_filter.dict()}
-            for collection_filter in filters
-        }
-
         return filtered_collection
 
 

--- a/openff/qcsubmit/tests/results/conftest.py
+++ b/openff/qcsubmit/tests/results/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+from openff.toolkit.topology import Molecule
+from qcportal.models import ObjectId
+
+from openff.qcsubmit.results import BasicResult, BasicResultCollection
+
+
+@pytest.fixture()
+def basic_result_collection() -> BasicResultCollection:
+    """Create a basic collection which can be filtered."""
+
+    return BasicResultCollection(
+        entries={
+            "http://localhost:442": [
+                BasicResult(
+                    record_id=ObjectId(str(i + 1)),
+                    cmiles=Molecule.from_smiles(smiles).to_smiles(mapped=True),
+                    inchi_key=Molecule.from_smiles(smiles).to_inchikey(),
+                )
+                for i, smiles in enumerate(["CO", "CCO", "CCO", "CCCO"])
+            ],
+            "http://localhost:443": [
+                BasicResult(
+                    record_id=ObjectId(str(i + 1)),
+                    cmiles=Molecule.from_smiles(smiles).to_smiles(mapped=True),
+                    inchi_key=Molecule.from_smiles(smiles).to_inchikey(),
+                )
+                for i, smiles in enumerate(["C=O", "CC=O", "CC=O", "CCC=O"])
+            ],
+        }
+    )

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -20,3 +20,6 @@ def test_apply_filter(basic_result_collection, caplog):
 
     assert filtered_collection.n_results == 4
     assert "4 results were removed" in caplog.text
+
+    assert "applied-filters" in filtered_collection.provenance
+    assert "DummyFilter-0" in filtered_collection.provenance["applied-filters"]

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -1,0 +1,22 @@
+import logging
+
+from openff.qcsubmit.results.filters import ResultFilter
+
+
+def test_apply_filter(basic_result_collection, caplog):
+    class DummyFilter(ResultFilter):
+        def _apply(self, result_collection):
+
+            result_collection.entries = {
+                "http://localhost:442": result_collection.entries[
+                    "http://localhost:442"
+                ]
+            }
+
+            return result_collection
+
+    with caplog.at_level(logging.INFO):
+        filtered_collection = DummyFilter().apply(basic_result_collection)
+
+    assert filtered_collection.n_results == 4
+    assert "4 results were removed" in caplog.text

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -188,13 +188,17 @@ def test_base_filter(basic_result_collection):
 
             return result_collection
 
-    filtered_collection = basic_result_collection.filter(DummyFilter())
+    filtered_collection = basic_result_collection.filter(
+        DummyFilter(),
+        DummyFilter(),
+    )
 
     assert filtered_collection.n_results == 4
     assert filtered_collection.n_molecules == 3
 
     assert "applied-filters" in filtered_collection.provenance
-    assert "DummyFilter" in filtered_collection.provenance["applied-filters"]
+    assert "DummyFilter-0" in filtered_collection.provenance["applied-filters"]
+    assert "DummyFilter-1" in filtered_collection.provenance["applied-filters"]
 
 
 @pytest.mark.parametrize(

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -16,6 +16,7 @@ from openff.qcsubmit.results import (
     OptimizationResultCollection,
     TorsionDriveResultCollection,
 )
+from openff.qcsubmit.results.filters import ResultFilter
 from openff.qcsubmit.results.results import OptimizationResult, _BaseResultCollection
 from openff.qcsubmit.tests import does_not_raise
 
@@ -173,6 +174,27 @@ def test_base_validate_record_types():
 
     with pytest.raises(RecordTypeError, match="The collection contained a records"):
         _BaseResultCollection._validate_record_types(records, OptimizationRecord)
+
+
+def test_base_filter(basic_result_collection):
+    class DummyFilter(ResultFilter):
+        def _apply(self, result_collection):
+
+            result_collection.entries = {
+                "http://localhost:442": result_collection.entries[
+                    "http://localhost:442"
+                ]
+            }
+
+            return result_collection
+
+    filtered_collection = basic_result_collection.filter(DummyFilter())
+
+    assert filtered_collection.n_results == 4
+    assert filtered_collection.n_molecules == 3
+
+    assert "applied-filters" in filtered_collection.provenance
+    assert "DummyFilter" in filtered_collection.provenance["applied-filters"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR exposes the initial API for filtering the results collections introduced in #106. It allows collections to be filtered directly:

```
filtered_collection = basic_result_collection.filter(
    # Exclude specific SMILES from the set, e.g. a training set.
    SMILESFilter(smiles_to_exclude=[...]),
    # Retain only records computed for molecules which match a set of 
    # SMARTS, e.g. a set of SMARTS associated with parameters. that will be trained.
    SMARTSFilter(smarts_to_include=[...], 
)
```
where each filter is sequentially applied or alternatively individual filters can be applied:

```
filter = SMILESFilter(smiles_to_include=[...])
filtered_collection = filter.apply(basic_result_collection)
```

Provenance about the applied filters will be stored in a new result collection provenance field:

```
>>> filtered_collection.provenance["applied-filters"]

{
    'SMILESFilter-0': {'smiles_to_exclude': [...]},
    'SMARTSFilter-1': {'smarts_to_include': [...]},
}
```

## Status
- [X] Ready to go