### PR TITLE
Add helpers to mock result collections

### DIFF
--- a/openff/qcsubmit/tests/results/__init__.py
+++ b/openff/qcsubmit/tests/results/__init__.py
@@ -1,0 +1,192 @@
+import copy
+
+from pydantic import BaseModel
+from qcelemental.models import DriverEnum
+from qcportal.models import (
+    ObjectId,
+    OptimizationRecord,
+    OptimizationSpecification,
+    QCSpecification,
+    ResultRecord,
+    TorsionDriveRecord,
+)
+from qcportal.models.records import RecordStatusEnum
+from qcportal.models.torsiondrive import TDKeywords
+
+from openff.qcsubmit.results import (
+    BasicResult,
+    BasicResultCollection,
+    OptimizationResult,
+    OptimizationResultCollection,
+    TorsionDriveResult,
+    TorsionDriveResultCollection,
+)
+
+
+class _FractalClient(BaseModel):
+
+    address: str
+
+
+def mock_basic_result_collection(molecules, monkeypatch) -> BasicResultCollection:
+
+    collection = BasicResultCollection(
+        entries={
+            address: [
+                BasicResult(
+                    record_id=ObjectId(str(i + 1)),
+                    cmiles=molecule.to_smiles(mapped=True),
+                    inchi_key=molecule.to_inchikey(),
+                )
+                for i, molecule in enumerate(molecules[address])
+            ]
+            for address in molecules
+        }
+    )
+
+    monkeypatch.setattr(
+        BasicResultCollection,
+        "to_records",
+        lambda self: [
+            ResultRecord(
+                id=entry.record_id,
+                program="psi4",
+                driver=DriverEnum.gradient,
+                method="scf",
+                basis="sto-3g",
+                molecule=entry.record_id,
+                status=RecordStatusEnum.complete,
+                client=_FractalClient(address=address),
+            )
+            for address, entries in self.entries.items()
+            for entry in entries
+        ],
+    )
+
+    monkeypatch.setattr(
+        ResultRecord,
+        "get_molecule",
+        lambda self: molecules[self.client.address][int(self.id) - 1].to_qcschema(),
+    )
+
+    return collection
+
+
+def mock_optimization_result_collection(
+    molecules, monkeypatch
+) -> OptimizationResultCollection:
+
+    collection = OptimizationResultCollection(
+        entries={
+            address: [
+                OptimizationResult(
+                    record_id=ObjectId(str(i + 1)),
+                    cmiles=molecule.to_smiles(mapped=True),
+                    inchi_key=molecule.to_inchikey(),
+                )
+                for i, molecule in enumerate(molecules[address])
+            ]
+            for address in molecules
+        }
+    )
+
+    monkeypatch.setattr(
+        OptimizationResultCollection,
+        "to_records",
+        lambda self: [
+            OptimizationRecord(
+                id=entry.record_id,
+                program="psi4",
+                qc_spec=QCSpecification(
+                    driver=DriverEnum.gradient,
+                    method="scf",
+                    basis="sto-3g",
+                    program="psi4",
+                ),
+                initial_molecule=ObjectId(entry.record_id),
+                status=RecordStatusEnum.complete,
+                client=_FractalClient(address=address),
+            )
+            for address, entries in self.entries.items()
+            for entry in entries
+        ],
+    )
+
+    monkeypatch.setattr(
+        OptimizationRecord,
+        "get_final_molecule",
+        lambda self: molecules[self.client.address][int(self.id) - 1].to_qcschema(),
+    )
+
+    return collection
+
+
+def mock_torsion_drive_result_collection(
+    molecules, monkeypatch
+) -> TorsionDriveResultCollection:
+
+    collection = TorsionDriveResultCollection(
+        entries={
+            address: [
+                TorsionDriveResult(
+                    record_id=ObjectId(str(i + 1)),
+                    cmiles=molecule.to_smiles(mapped=True),
+                    inchi_key=molecule.to_inchikey(),
+                )
+                for i, molecule in enumerate(molecules[address])
+            ]
+            for address in molecules
+        }
+    )
+
+    monkeypatch.setattr(
+        TorsionDriveResultCollection,
+        "to_records",
+        lambda self: [
+            TorsionDriveRecord(
+                id=entry.record_id,
+                qc_spec=QCSpecification(
+                    driver=DriverEnum.gradient,
+                    method="scf",
+                    basis="sto-3g",
+                    program="psi4",
+                ),
+                optimization_spec=OptimizationSpecification(
+                    program="geometric", keywords={}
+                ),
+                initial_molecule=[
+                    ObjectId(i + 1)
+                    for i in range(
+                        molecules[address][int(entry.record_id) - 1].n_conformers
+                    )
+                ],
+                status=RecordStatusEnum.complete,
+                client=_FractalClient(address=address),
+                keywords=TDKeywords(dihedrals=[], grid_spacing=[]),
+                final_energy_dict={},
+                optimization_history={},
+                minimum_positions={},
+            )
+            for address, entries in self.entries.items()
+            for entry in entries
+        ],
+    )
+
+    def get_molecules(self):
+
+        return_value = []
+
+        for molecule_id in self.initial_molecule:
+
+            molecule = copy.deepcopy(molecules[self.client.address][int(self.id) - 1])
+            molecule._conformers = [molecule.conformers[int(molecule_id) - 1]]
+
+            return_value.append(molecule.to_qcschema())
+
+        return return_value
+
+    monkeypatch.setattr(
+        TorsionDriveRecord, "get_final_molecules", lambda self: get_molecules(self)
+    )
+
+    return collection

--- a/openff/qcsubmit/tests/results/conftest.py
+++ b/openff/qcsubmit/tests/results/conftest.py
@@ -1,31 +1,157 @@
+import numpy as np
 import pytest
 from openff.toolkit.topology import Molecule
-from qcportal.models import ObjectId
+from simtk import unit
 
-from openff.qcsubmit.results import BasicResult, BasicResultCollection
+from openff.qcsubmit.results import (
+    BasicResultCollection,
+    OptimizationResultCollection,
+    TorsionDriveResultCollection,
+)
+from openff.qcsubmit.tests.results import (
+    mock_basic_result_collection,
+    mock_optimization_result_collection,
+    mock_torsion_drive_result_collection,
+)
+
+
+def _smiles_to_molecule(smiles: str) -> Molecule:
+
+    molecule: Molecule = Molecule.from_smiles(smiles, allow_undefined_stereo=True)
+    molecule.generate_conformers(n_conformers=1)
+
+    return molecule
 
 
 @pytest.fixture()
-def basic_result_collection() -> BasicResultCollection:
+def basic_result_collection(monkeypatch) -> BasicResultCollection:
     """Create a basic collection which can be filtered."""
 
-    return BasicResultCollection(
-        entries={
-            "http://localhost:442": [
-                BasicResult(
-                    record_id=ObjectId(str(i + 1)),
-                    cmiles=Molecule.from_smiles(smiles).to_smiles(mapped=True),
-                    inchi_key=Molecule.from_smiles(smiles).to_inchikey(),
-                )
-                for i, smiles in enumerate(["CO", "CCO", "CCO", "CCCO"])
-            ],
-            "http://localhost:443": [
-                BasicResult(
-                    record_id=ObjectId(str(i + 1)),
-                    cmiles=Molecule.from_smiles(smiles).to_smiles(mapped=True),
-                    inchi_key=Molecule.from_smiles(smiles).to_inchikey(),
-                )
-                for i, smiles in enumerate(["C=O", "CC=O", "CC=O", "CCC=O"])
-            ],
-        }
+    smiles = {
+        "http://localhost:442": [
+            _smiles_to_molecule(smiles) for smiles in ["CO", "CCO", "CCO", "CCCO"]
+        ],
+        "http://localhost:443": [
+            _smiles_to_molecule(smiles) for smiles in ["C=O", "CC=O", "CC=O", "CCC=O"]
+        ],
+    }
+
+    return mock_basic_result_collection(smiles, monkeypatch)
+
+
+@pytest.fixture()
+def h_bond_basic_result_collection(monkeypatch) -> BasicResultCollection:
+    """Create a basic collection which can be filtered."""
+
+    # Create a molecule which contains internal h-bonds.
+    h_bond_molecule = Molecule.from_smiles("O\C=C/C=O")
+    h_bond_molecule.add_conformer(
+        np.array(
+            [
+                [0.5099324, -1.93893933, 0.62593794],
+                [-0.11678398, -0.78811455, 0.23294619],
+                [0.54772449, 0.32974607, -0.06212188],
+                [2.01855326, 0.32851657, 0.03836611],
+                [2.68037677, -0.68459523, -0.15270394],
+                [1.47464514, -1.82358289, 0.65648550],
+                [-1.1913352, -0.90038794, 0.19441436],
+                [0.04801793, 1.23909473, -0.37244973],
+                [2.49137521, 1.29117954, 0.29548031],
+            ]
+        )
+        * unit.angstrom
     )
+
+    smiles = {
+        "http://localhost:442": [h_bond_molecule],
+        "http://localhost:443": [_smiles_to_molecule("CO")],
+    }
+
+    return mock_basic_result_collection(smiles, monkeypatch)
+
+
+@pytest.fixture()
+def optimization_result_collection(monkeypatch) -> OptimizationResultCollection:
+    """Create a basic collection which can be filtered."""
+
+    # Create a molecule which contains internal h-bonds.
+    h_bond_molecule = Molecule.from_smiles("O\C=C/C=O")
+    h_bond_molecule.add_conformer(
+        np.array(
+            [
+                [0.5099324, -1.93893933, 0.62593794],
+                [-0.11678398, -0.78811455, 0.23294619],
+                [0.54772449, 0.32974607, -0.06212188],
+                [2.01855326, 0.32851657, 0.03836611],
+                [2.68037677, -0.68459523, -0.15270394],
+                [1.47464514, -1.82358289, 0.65648550],
+                [-1.1913352, -0.90038794, 0.19441436],
+                [0.04801793, 1.23909473, -0.37244973],
+                [2.49137521, 1.29117954, 0.29548031],
+            ]
+        )
+        * unit.angstrom
+    )
+
+    smiles = {
+        "http://localhost:442": [
+            _smiles_to_molecule(smiles) for smiles in ["CO", "CCO", "CCO", "CCCO"]
+        ],
+        "http://localhost:443": [h_bond_molecule],
+    }
+
+    return mock_optimization_result_collection(smiles, monkeypatch)
+
+
+@pytest.fixture()
+def torsion_drive_result_collection(monkeypatch) -> TorsionDriveResultCollection:
+    """Create a basic collection which can be filtered."""
+
+    # Create a molecule which contains atleast one internal h-bond.
+    h_bond_molecule = Molecule.from_smiles("O\C=C/C=O")
+    h_bond_molecule.add_conformer(
+        np.array(
+            [
+                [0.5099324, -1.93893933, 0.62593794],
+                [-0.11678398, -0.78811455, 0.23294619],
+                [0.54772449, 0.32974607, -0.06212188],
+                [2.01855326, 0.32851657, 0.03836611],
+                [2.68657255, 1.32275689, -0.21883053],
+                [-0.13074179, -2.64932013, 0.79858345],
+                [-1.1913352, -0.90038794, 0.19441436],
+                [0.04801793, 1.23909473, -0.37244973],
+                [2.48549175, -0.61807805, 0.35823375],
+            ]
+        )
+        * unit.angstrom
+    )
+    h_bond_molecule.add_conformer(
+        np.array(
+            [
+                [0.5099324, -1.93893933, 0.62593794],
+                [-0.11678398, -0.78811455, 0.23294619],
+                [0.54772449, 0.32974607, -0.06212188],
+                [2.01855326, 0.32851657, 0.03836611],
+                [2.68037677, -0.68459523, -0.15270394],
+                [1.47464514, -1.82358289, 0.65648550],
+                [-1.1913352, -0.90038794, 0.19441436],
+                [0.04801793, 1.23909473, -0.37244973],
+                [2.49137521, 1.29117954, 0.29548031],
+            ]
+        )
+        * unit.angstrom
+    )
+
+    # Create a molecule which contains no internal h-bonds.
+    no_h_bond_molecule = Molecule.from_smiles("O\C=C/C=O")
+    no_h_bond_molecule.add_conformer(h_bond_molecule.conformers[0])
+    no_h_bond_molecule.add_conformer(
+        h_bond_molecule.conformers[0] + 1.0 * unit.angstrom
+    )
+
+    smiles = {
+        "http://localhost:442": [h_bond_molecule],
+        "http://localhost:443": [no_h_bond_molecule],
+    }
+
+    return mock_torsion_drive_result_collection(smiles, monkeypatch)


### PR DESCRIPTION
## Description

This PR adds helper utilities to mock result collections and their associated QC records. This allows for rapid testing without calling out to QCA, and allows bespoke results to be generated depending on the requirements of each test.

## Status
- [X] Ready to go