### PR TITLE
Add cached versions of QC record and molecule queries

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -27,6 +27,8 @@ dependencies:
   - fragmenter ==0.0.7
   - basis_set_exchange
   - typing-extensions
+  - requests-mock
+  - cachetools
 
     # Pip-only installs
 #  - pip:

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -31,6 +31,8 @@ dependencies:
   - fragmenter ==0.0.7
   - basis_set_exchange
   - typing-extensions
+  - requests-mock
+  - cachetools
 
     # Pip-only installs
 #  - pip:

--- a/openff/qcsubmit/results/caching.py
+++ b/openff/qcsubmit/results/caching.py
@@ -1,0 +1,329 @@
+"""A module which contains helpers for retrieving data from QCA and caching the
+results in memory for future requests."""
+from functools import lru_cache
+from typing import TYPE_CHECKING, Dict, List, Tuple, TypeVar
+
+import numpy
+from cachetools import LRUCache
+from openff.toolkit.topology import Molecule
+from qcportal import FractalClient
+from qcportal.models import Molecule as QCMolecule
+from qcportal.models import TorsionDriveRecord
+from qcportal.models.records import OptimizationRecord, RecordBase, ResultRecord
+from simtk import unit
+
+if TYPE_CHECKING:
+    from openff.qcsubmit.results.results import (
+        BasicResult,
+        OptimizationResult,
+        TorsionDriveResult,
+        _BaseResult,
+    )
+
+    R = TypeVar("R", bound=_BaseResult)
+
+S = TypeVar("S", bound=RecordBase)
+T = TypeVar("T")
+
+RecordAndMolecule = Tuple[RecordBase, Molecule]
+
+_record_cache = LRUCache(maxsize=20000)
+
+_molecule_cache = LRUCache(maxsize=20000)
+
+_grid_id_cache = LRUCache(maxsize=40000)
+
+
+def clear_results_caches():
+    """Clear the internal results caches."""
+
+    _record_cache.clear()
+    _molecule_cache.clear()
+    _grid_id_cache.clear()
+
+
+def _batched_indices(indices: List[T], batch_size: int) -> List[List[T]]:
+    """Split a list of indices into batches.
+
+    Args:
+        indices: The indices to split.
+        batch_size: The size to split the indices into.
+
+    Returns:
+        A list of list batches of indices.
+    """
+    return [indices[i : i + batch_size] for i in range(0, len(indices), batch_size)]
+
+
+@lru_cache()
+def _cached_fractal_client(address: str) -> FractalClient:
+    """Returns a cached copy of a fractal client."""
+    return FractalClient(address)
+
+
+def cached_query_procedures(client_address: str, record_ids: List[str]) -> List[S]:
+    """A cached version of ``FractalClient.query_procedures``.
+
+    Args:
+        client_address: The address of the running QCFractal instance to query.
+        record_ids: The ids of the records to query.
+
+    Returns:
+        The returned records.
+    """
+
+    client_address = client_address.rstrip("/")
+
+    missing_record_ids = list(
+        {
+            record_id
+            for record_id in record_ids
+            if (client_address, record_id) not in _record_cache
+        }
+    )
+
+    client = _cached_fractal_client(client_address)
+
+    for batch_ids in _batched_indices(missing_record_ids, client.query_limit):
+        for record in client.query_procedures(batch_ids):
+
+            if record.status.value.upper() != "COMPLETE":
+                # Don't cache incomplete records.
+                continue
+
+            _record_cache[(client_address, record.id)] = record
+
+    return [_record_cache[(client_address, record_id)] for record_id in record_ids]
+
+
+def cached_query_molecules(
+    client_address: str, molecule_ids: List[str]
+) -> List[QCMolecule]:
+    """A cached version of ``FractalClient.query_molecules``.
+
+    Args:
+        client_address: The address of the running QCFractal instance to query.
+        molecule_ids: The ids of the molecules to query.
+
+    Returns:
+        The returned molecules.
+    """
+
+    client_address = client_address.rstrip("/")
+
+    missing_molecule_ids = list(
+        {
+            molecule_id
+            for molecule_id in molecule_ids
+            if (client_address, molecule_id) not in _molecule_cache
+        }
+    )
+
+    client = _cached_fractal_client(client_address)
+
+    for batch_ids in _batched_indices(missing_molecule_ids, client.query_limit):
+        for molecule in client.query_molecules(batch_ids):
+            _molecule_cache[(client_address, molecule.id)] = molecule
+
+    return [
+        _molecule_cache[(client_address, molecule_id)] for molecule_id in molecule_ids
+    ]
+
+
+def _cached_query_single_structure_results(
+    client_address: str, results: List["R"], molecule_attribute: str
+) -> List[Tuple[S, Molecule]]:
+    """A utility function to batch query a server for the records and their
+    corresponding molecules referenced by a list of result entries.
+
+    Args:
+        client_address: The address of the running QCFractal instance to query.
+        results: The result objects to query.
+        molecule_attribute: The name of the field on the record which stores the
+            id of the molecule associated with the record.
+
+    Returns:
+        A list of tuples of the returned records and molecules.
+    """
+
+    qc_records: Dict[str, S] = {
+        qc_record.id: qc_record
+        for qc_record in cached_query_procedures(
+            client_address, [result.record_id for result in results]
+        )
+    }
+
+    qc_record_to_molecule_id = {
+        qc_record.id: getattr(qc_record, molecule_attribute)
+        for qc_record in qc_records.values()
+    }
+
+    qc_molecules = {
+        molecule.id: molecule
+        for molecule in cached_query_molecules(
+            client_address, [*qc_record_to_molecule_id.values()]
+        )
+    }
+
+    return_values = []
+
+    for result in results:
+
+        qc_record = qc_records[result.record_id]
+        qc_molecule = qc_molecules[qc_record_to_molecule_id[result.record_id]]
+
+        molecule: Molecule = Molecule.from_mapped_smiles(
+            result.cmiles, allow_undefined_stereo=True
+        )
+
+        molecule.add_conformer(
+            numpy.array(qc_molecule.geometry, float).reshape(-1, 3) * unit.bohr
+        )
+
+        return_values.append((qc_record, molecule))
+
+    return return_values
+
+
+def cached_query_basic_results(
+    client_address: str, results: List["BasicResult"]
+) -> List[Tuple[ResultRecord, Molecule]]:
+    """Returns the QC record and corresponding molecule object associated with each
+    of the specified result entries.
+
+    The molecule will contain the conformer referenced by the record.
+
+    Args:
+        client_address: The address of the running QCFractal instance to query.
+        results: The result objects to query.
+
+    Returns:
+        A list of tuples of the returned records and molecules.
+    """
+
+    return _cached_query_single_structure_results(client_address, results, "molecule")
+
+
+def cached_query_optimization_results(
+    client_address: str, results: List["OptimizationResult"]
+) -> List[Tuple[OptimizationRecord, Molecule]]:
+    """Returns the QC record and corresponding molecule object associated with each
+    of the specified result entries.
+
+    The molecule will contain the minimum energy conformer referenced by the record.
+
+    Args:
+        client_address: The address of the running QCFractal instance to query.
+        results: The result objects to query.
+
+    Returns:
+        A list of tuples of the returned records and molecules.
+    """
+
+    return _cached_query_single_structure_results(
+        client_address, results, "final_molecule"
+    )
+
+
+def _cached_torsion_drive_molecule_ids(
+    client_address: str, qc_records: List[TorsionDriveRecord]
+) -> Dict[Tuple[str, Tuple[int, ...]], str]:
+
+    client_address = client_address.rstrip("/")
+
+    optimization_ids = {
+        (qc_record.id, grid_id): qc_record.optimization_history[grid_id][minimum_idx]
+        for qc_record in qc_records
+        for grid_id, minimum_idx in qc_record.minimum_positions.items()
+    }
+
+    missing_optimization_ids = {
+        grid_tuple: optimization_id
+        for grid_tuple, optimization_id in optimization_ids.items()
+        if (client_address, *grid_tuple) not in _grid_id_cache
+    }
+
+    client = _cached_fractal_client(client_address)
+
+    qc_optimizations = {
+        record.id: record
+        for batch_ids in _batched_indices(
+            [*missing_optimization_ids.values()], client.query_limit
+        )
+        for record in client.query_procedures(batch_ids)
+    }
+
+    for grid_tuple, optimization_id in missing_optimization_ids.items():
+
+        qc_optimization = qc_optimizations[optimization_id]
+
+        if qc_optimization.status.value.upper() != "COMPLETE":
+            # Don't cache incomplete records.
+            continue
+
+        _grid_id_cache[(client_address, *grid_tuple)] = qc_optimization.final_molecule
+
+    return {
+        grid_tuple: _grid_id_cache[(client_address, *grid_tuple)]
+        for grid_tuple in optimization_ids
+    }
+
+
+def cached_query_torsion_drive_results(
+    client_address: str, results: List["TorsionDriveResult"]
+) -> List[Tuple[TorsionDriveRecord, Molecule]]:
+    """Returns the QC record and corresponding molecule object associated with each
+    of the specified result entries.
+
+    The molecule will contain the minimum energy conformer at each grid id. The grid
+    ids themselves will be stored in ``molecule.properties["grid_ids"]``, such
+    that ``molecule.conformers[i]`` corresponds to the minimum energy structure
+    at grid id ``molecule.properties["grid_ids"][i]``.
+
+    Args:
+        client_address: The address of the running QCFractal instance to retrieve the
+            results from.
+        results: The results to retrieve.
+    """
+
+    qc_records: Dict[str, TorsionDriveRecord] = {
+        qc_record.id: qc_record
+        for qc_record in cached_query_procedures(
+            client_address, [result.record_id for result in results]
+        )
+    }
+
+    molecule_ids = _cached_torsion_drive_molecule_ids(
+        client_address, [*qc_records.values()]
+    )
+
+    qc_molecules = {
+        molecule.id: molecule
+        for molecule in cached_query_molecules(client_address, [*molecule_ids.values()])
+    }
+
+    return_values = []
+
+    for result in results:
+
+        qc_record = qc_records[result.record_id]
+
+        grid_ids = [*qc_record.minimum_positions]
+
+        qc_grid_molecules = [
+            qc_molecules[molecule_ids[(qc_record.id, grid_id)]] for grid_id in grid_ids
+        ]
+
+        molecule: Molecule = Molecule.from_mapped_smiles(
+            result.cmiles, allow_undefined_stereo=True
+        )
+        molecule._conformers = [
+            numpy.array(qc_molecule.geometry, float).reshape(-1, 3) * unit.bohr
+            for qc_molecule in qc_grid_molecules
+        ]
+
+        molecule.properties["grid_ids"] = grid_ids
+
+        return_values.append((qc_record, molecule))
+
+    return return_values

--- a/openff/qcsubmit/results/caching.py
+++ b/openff/qcsubmit/results/caching.py
@@ -29,9 +29,9 @@ RecordAndMolecule = Tuple[RecordBase, Molecule]
 
 _record_cache = LRUCache(maxsize=20000)
 
-_molecule_cache = LRUCache(maxsize=20000)
+_molecule_cache = LRUCache(maxsize=240000)
 
-_grid_id_cache = LRUCache(maxsize=40000)
+_grid_id_cache = LRUCache(maxsize=240000)
 
 
 def clear_results_caches():

--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -2,13 +2,8 @@ import abc
 import logging
 from typing import TYPE_CHECKING, List, Optional, TypeVar
 
-import numpy as np
 from openff.toolkit.topology import Molecule
 from pydantic import BaseModel, Field, root_validator
-from qcportal.models import Molecule as QCMolecule
-from qcportal.models import OptimizationRecord, ResultRecord, TorsionDriveRecord
-from qcportal.models.records import RecordBase
-from simtk import unit
 
 if TYPE_CHECKING:
 
@@ -23,112 +18,6 @@ class ResultFilter(BaseModel, abc.ABC):
     """The base class for a filter which will retain selection of QC records based on
     a specific criterion.
     """
-
-    @classmethod
-    def _basic_record_to_molecule(cls, cmiles: str, record: ResultRecord) -> Molecule:
-        """Creates a molecule object from a result record, storing the records
-        conformer on the molecule.
-
-        Args:
-            cmiles: The CMILES associated with the record.
-            record: The record to map to an OpenFF molecule.
-
-        Returns:
-            The record mapped to an OpenFF molecule.
-        """
-
-        qc_molecule: QCMolecule = record.get_molecule()
-
-        molecule: Molecule = Molecule.from_mapped_smiles(
-            cmiles, allow_undefined_stereo=True
-        )
-
-        molecule.add_conformer(
-            np.array(qc_molecule.geometry, float).reshape(-1, 3) * unit.bohr
-        )
-
-        return molecule
-
-    @classmethod
-    def _optimization_record_to_molecule(
-        cls, cmiles: str, record: OptimizationRecord
-    ) -> Molecule:
-        """Creates a molecule object from an optimization record, storing the lowest
-        energy conformer on the molecule.
-
-        Args:
-            cmiles: The CMILES associated with the record.
-            record: The record to map to an OpenFF molecule.
-
-        Returns:
-            The record mapped to an OpenFF molecule.
-        """
-
-        qc_molecule: QCMolecule = record.get_final_molecule()
-
-        molecule: Molecule = Molecule.from_mapped_smiles(
-            cmiles, allow_undefined_stereo=True
-        )
-
-        molecule.add_conformer(
-            np.array(qc_molecule.geometry, float).reshape(-1, 3) * unit.bohr
-        )
-
-        return molecule
-
-    @classmethod
-    def _torsion_drive_record_to_molecule(
-        cls, cmiles: str, record: TorsionDriveRecord
-    ) -> Molecule:
-        """Creates a molecule object from an torsion drive record, storing the lowest
-        energy conformer at each grid angle on the molecule.
-
-        Args:
-            cmiles: The CMILES associated with the record.
-            record: The record to map to an OpenFF molecule.
-
-        Returns:
-            The record mapped to an OpenFF molecule.
-        """
-
-        molecule: Molecule = Molecule.from_mapped_smiles(
-            cmiles, allow_undefined_stereo=True
-        )
-        qc_molecule: QCMolecule
-
-        for qc_molecule in record.get_final_molecules().values():
-
-            molecule.add_conformer(
-                np.array(qc_molecule.geometry, float).reshape(-1, 3) * unit.bohr
-            )
-
-        return molecule
-
-    @classmethod
-    def _record_to_molecule(cls, cmiles: str, record: RecordBase) -> Molecule:
-        """Maps a record to an OpenFF molecule object.
-
-        Notes:
-            * For ``ResultRecord`` objects the single structure associated with the
-              record will be returned.
-            * For ``OptimizationRecord`` objects the minimum energy structure associated
-              with the record will be returned.
-            * For ``TorsionDriveRecord`` objects the minimum energy structure
-              at each grid angle will be returned.
-        """
-
-        if isinstance(record, ResultRecord):
-            return cls._basic_record_to_molecule(cmiles, record)
-        elif isinstance(record, OptimizationRecord):
-            return cls._optimization_record_to_molecule(cmiles, record)
-        elif isinstance(record, TorsionDriveRecord):
-            return cls._torsion_drive_record_to_molecule(cmiles, record)
-        else:
-
-            raise NotImplementedError(
-                "Only ``ResultRecord``, ``OptimizationRecord``, and "
-                "``TorsionDriveRecord`` objects are supported."
-            )
 
     @abc.abstractmethod
     def _apply(self, result_collection: "T") -> "T":

--- a/openff/qcsubmit/tests/conftest.py
+++ b/openff/qcsubmit/tests/conftest.py
@@ -11,6 +11,6 @@ def public_client():
     return FractalClient()
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def clear_results_caches_before_tests():
     clear_results_caches()

--- a/openff/qcsubmit/tests/conftest.py
+++ b/openff/qcsubmit/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+from qcportal import FractalClient
+
+from openff.qcsubmit.results.caching import clear_results_caches
+
+
+@pytest.fixture
+def public_client():
+    """Setup a new connection to the public qcarchive client."""
+
+    return FractalClient()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_results_caches_before_tests():
+    clear_results_caches()

--- a/openff/qcsubmit/tests/results/conftest.py
+++ b/openff/qcsubmit/tests/results/conftest.py
@@ -44,7 +44,7 @@ def h_bond_basic_result_collection(monkeypatch) -> BasicResultCollection:
     """Create a basic collection which can be filtered."""
 
     # Create a molecule which contains internal h-bonds.
-    h_bond_molecule = Molecule.from_smiles("O\C=C/C=O")
+    h_bond_molecule = Molecule.from_smiles(r"O\C=C/C=O")
     h_bond_molecule.add_conformer(
         np.array(
             [
@@ -75,7 +75,7 @@ def optimization_result_collection(monkeypatch) -> OptimizationResultCollection:
     """Create a basic collection which can be filtered."""
 
     # Create a molecule which contains internal h-bonds.
-    h_bond_molecule = Molecule.from_smiles("O\C=C/C=O")
+    h_bond_molecule = Molecule.from_smiles(r"O\C=C/C=O")
     h_bond_molecule.add_conformer(
         np.array(
             [
@@ -108,7 +108,7 @@ def torsion_drive_result_collection(monkeypatch) -> TorsionDriveResultCollection
     """Create a basic collection which can be filtered."""
 
     # Create a molecule which contains atleast one internal h-bond.
-    h_bond_molecule = Molecule.from_smiles("O\C=C/C=O")
+    h_bond_molecule = Molecule.from_smiles(r"O\C=C/C=O")
     h_bond_molecule.add_conformer(
         np.array(
             [
@@ -143,7 +143,7 @@ def torsion_drive_result_collection(monkeypatch) -> TorsionDriveResultCollection
     )
 
     # Create a molecule which contains no internal h-bonds.
-    no_h_bond_molecule = Molecule.from_smiles("O\C=C/C=O")
+    no_h_bond_molecule = Molecule.from_smiles(r"O\C=C/C=O")
     no_h_bond_molecule.add_conformer(h_bond_molecule.conformers[0])
     no_h_bond_molecule.add_conformer(
         h_bond_molecule.conformers[0] + 1.0 * unit.angstrom

--- a/openff/qcsubmit/tests/results/test_caching.py
+++ b/openff/qcsubmit/tests/results/test_caching.py
@@ -1,0 +1,143 @@
+import pytest
+import requests_mock
+from openff.toolkit.topology import Molecule
+from qcportal.models import ObjectId
+
+from openff.qcsubmit.results import BasicResult, OptimizationResult, TorsionDriveResult
+from openff.qcsubmit.results.caching import (
+    _batched_indices,
+    _grid_id_cache,
+    _molecule_cache,
+    _record_cache,
+    cached_query_basic_results,
+    cached_query_molecules,
+    cached_query_optimization_results,
+    cached_query_procedures,
+    cached_query_torsion_drive_results,
+    clear_results_caches,
+)
+
+
+def test_batched_indices():
+    assert _batched_indices([1, 2, 3, 4], 3) == [[1, 2, 3], [4]]
+
+
+def test_cached_query_procedures(public_client):
+
+    clear_results_caches()
+    assert len(_record_cache) == 0
+
+    record_ids = ["32651863", "32651864"]
+
+    records = cached_query_procedures(public_client.address, record_ids)
+
+    assert len(records) == 2
+    assert {record.id for record in records} == {*record_ids}
+
+    assert len(_record_cache) == 2
+
+    # The request mocker would raise an exception if the client tries to reach out
+    # to the server.
+    with requests_mock.Mocker():
+        cached_query_procedures(public_client.address, record_ids)
+
+
+def test_cached_query_molecule(public_client):
+
+    clear_results_caches()
+    assert len(_molecule_cache) == 0
+
+    molecule_ids = ["25696236", "25696152"]
+
+    molecules = cached_query_molecules(public_client.address, molecule_ids)
+
+    assert len(molecules) == 2
+    assert {molecule.id for molecule in molecules} == {*molecule_ids}
+
+    assert len(_molecule_cache) == 2
+
+    # The request mocker would raise an exception if the client tries to reach out
+    # to the server.
+    with requests_mock.Mocker():
+        cached_query_molecules(public_client.address, molecule_ids)
+
+
+@pytest.mark.parametrize(
+    "result, query_function, expected_n_conformers",
+    [
+        (
+            BasicResult(
+                record_id=ObjectId("32651863"),
+                cmiles="[H:3][C:1]([H:4])([H:5])[O:2][H:6]",
+                inchi_key="",
+            ),
+            cached_query_basic_results,
+            1,
+        ),
+        (
+            OptimizationResult(
+                record_id=ObjectId("25724668"),
+                cmiles="[C:1]([H:2])([H:3])([H:4])[H:5]",
+                inchi_key="",
+            ),
+            cached_query_optimization_results,
+            1,
+        ),
+    ],
+)
+def test_record_to_molecule(
+    result, query_function, expected_n_conformers, public_client
+):
+
+    clear_results_caches()
+
+    expected_molecule = Molecule.from_mapped_smiles(result.cmiles)
+
+    records = query_function(public_client.address, [result])
+    assert len(records) == 1
+
+    record, molecule = records[0]
+
+    assert molecule.n_conformers == expected_n_conformers
+
+    are_isomorphic, _ = Molecule.are_isomorphic(molecule, expected_molecule)
+    assert are_isomorphic
+
+    # The request mocker would raise an exception if the client tries to reach out
+    # to the server.
+    with requests_mock.Mocker():
+        query_function(public_client.address, [result])
+
+
+def test_cached_query_torsion_drive_results(public_client):
+
+    clear_results_caches()
+    assert len(_grid_id_cache) == 0
+
+    result = TorsionDriveResult(
+        record_id=ObjectId("36633243"),
+        cmiles="[H:6][N:5]([H:7])[C:3](=[O:4])[C:1]#[N:2]",
+        inchi_key="",
+    )
+
+    expected_molecule = Molecule.from_mapped_smiles(result.cmiles)
+
+    records = cached_query_torsion_drive_results(public_client.address, [result])
+    assert len(records) == 1
+
+    record, molecule = records[0]
+
+    assert molecule.n_conformers == 24
+
+    assert "grid_ids" in molecule.properties
+    assert len(molecule.properties["grid_ids"]) == 24
+
+    are_isomorphic, _ = Molecule.are_isomorphic(molecule, expected_molecule)
+    assert are_isomorphic
+
+    assert len(_grid_id_cache) == 24
+
+    # The request mocker would raise an exception if the client tries to reach out
+    # to the server.
+    with requests_mock.Mocker():
+        cached_query_torsion_drive_results(public_client.address, [result])

--- a/openff/qcsubmit/tests/results/test_caching.py
+++ b/openff/qcsubmit/tests/results/test_caching.py
@@ -14,7 +14,6 @@ from openff.qcsubmit.results.caching import (
     cached_query_optimization_results,
     cached_query_procedures,
     cached_query_torsion_drive_results,
-    clear_results_caches,
 )
 
 
@@ -24,7 +23,6 @@ def test_batched_indices():
 
 def test_cached_query_procedures(public_client):
 
-    clear_results_caches()
     assert len(_record_cache) == 0
 
     record_ids = ["32651863", "32651864"]
@@ -44,7 +42,6 @@ def test_cached_query_procedures(public_client):
 
 def test_cached_query_molecule(public_client):
 
-    clear_results_caches()
     assert len(_molecule_cache) == 0
 
     molecule_ids = ["25696236", "25696152"]
@@ -89,8 +86,6 @@ def test_record_to_molecule(
     result, query_function, expected_n_conformers, public_client
 ):
 
-    clear_results_caches()
-
     expected_molecule = Molecule.from_mapped_smiles(result.cmiles)
 
     records = query_function(public_client.address, [result])
@@ -111,7 +106,6 @@ def test_record_to_molecule(
 
 def test_cached_query_torsion_drive_results(public_client):
 
-    clear_results_caches()
     assert len(_grid_id_cache) == 0
 
     result = TorsionDriveResult(

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -1,9 +1,7 @@
 import logging
 
 import pytest
-from openff.toolkit.topology import Molecule
 from pydantic import ValidationError
-from qcportal import FractalClient
 
 from openff.qcsubmit.results.filters import ResultFilter, SMARTSFilter, SMILESFilter
 
@@ -74,41 +72,3 @@ def test_molecule_filter_apply(result_filter, expected_ids, basic_result_collect
         assert entry_ids == {
             entry.record_id for entry in filtered_collection.entries[address]
         }
-
-
-@pytest.mark.parametrize(
-    "expected_cmiles, expected_n_conformers, record_id, molecule_function",
-    [
-        (
-            "[H:3][C:1]([H:4])([H:5])[O:2][H:6]",
-            1,
-            "32651863",
-            ResultFilter._basic_record_to_molecule,
-        ),
-        (
-            "[C:1]([H:2])([H:3])([H:4])[H:5]",
-            1,
-            "25724668",
-            ResultFilter._optimization_record_to_molecule,
-        ),
-        (
-            "[H:6][N:5]([H:7])[C:3](=[O:4])[C:1]#[N:2]",
-            24,
-            "36633243",
-            ResultFilter._torsion_drive_record_to_molecule,
-        ),
-    ],
-)
-def test_record_to_molecule(
-    expected_cmiles, expected_n_conformers, record_id, molecule_function
-):
-
-    expected_molecule = Molecule.from_mapped_smiles(expected_cmiles)
-
-    record = FractalClient().query_procedures(record_id)[0]
-
-    molecule = molecule_function(expected_cmiles, record)
-    assert molecule.n_conformers == expected_n_conformers
-
-    are_isomorphic, _ = Molecule.are_isomorphic(molecule, expected_molecule)
-    assert are_isomorphic

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -1,13 +1,11 @@
 import logging
 
 import pytest
+from openff.toolkit.topology import Molecule
 from pydantic import ValidationError
+from qcportal import FractalClient
 
-from openff.qcsubmit.results.filters import (
-    ResultFilter,
-    SMARTSFilter,
-    SMILESFilter,
-)
+from openff.qcsubmit.results.filters import ResultFilter, SMARTSFilter, SMILESFilter
 
 
 def test_apply_filter(basic_result_collection, caplog):
@@ -76,3 +74,41 @@ def test_molecule_filter_apply(result_filter, expected_ids, basic_result_collect
         assert entry_ids == {
             entry.record_id for entry in filtered_collection.entries[address]
         }
+
+
+@pytest.mark.parametrize(
+    "expected_cmiles, expected_n_conformers, record_id, molecule_function",
+    [
+        (
+            "[H:3][C:1]([H:4])([H:5])[O:2][H:6]",
+            1,
+            "32651863",
+            ResultFilter._basic_record_to_molecule,
+        ),
+        (
+            "[C:1]([H:2])([H:3])([H:4])[H:5]",
+            1,
+            "25724668",
+            ResultFilter._optimization_record_to_molecule,
+        ),
+        (
+            "[H:6][N:5]([H:7])[C:3](=[O:4])[C:1]#[N:2]",
+            24,
+            "36633243",
+            ResultFilter._torsion_drive_record_to_molecule,
+        ),
+    ],
+)
+def test_record_to_molecule(
+    expected_cmiles, expected_n_conformers, record_id, molecule_function
+):
+
+    expected_molecule = Molecule.from_mapped_smiles(expected_cmiles)
+
+    record = FractalClient().query_procedures(record_id)[0]
+
+    molecule = molecule_function(expected_cmiles, record)
+    assert molecule.n_conformers == expected_n_conformers
+
+    are_isomorphic, _ = Molecule.are_isomorphic(molecule, expected_molecule)
+    assert are_isomorphic

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -16,16 +16,10 @@ from openff.qcsubmit.results import (
     OptimizationResultCollection,
     TorsionDriveResultCollection,
 )
+from openff.qcsubmit.results.caching import clear_results_caches
 from openff.qcsubmit.results.filters import ResultFilter
 from openff.qcsubmit.results.results import OptimizationResult, _BaseResultCollection
 from openff.qcsubmit.tests import does_not_raise
-
-
-@pytest.fixture
-def public_client():
-    """Setup a new connection to the public qcarchive client."""
-
-    return FractalClient()
 
 
 def test_base_molecule_property():
@@ -127,25 +121,6 @@ def test_base_n_molecules_property():
     )
 
     assert collection.n_molecules == 2
-
-
-def test_base_query_in_chunks():
-
-    n_queries = 0
-
-    def _query_function(ids):
-
-        nonlocal n_queries
-        n_queries += 1
-
-        return [int(i) + 1 for i in ids]
-
-    result = _BaseResultCollection._query_in_chunks(
-        _query_function, ["1", "2", "3", "4", "5"], 2
-    )
-
-    assert result == [2, 3, 4, 5, 6]
-    assert n_queries == 3
 
 
 def test_base_validate_record_types():
@@ -256,6 +231,7 @@ def test_collection_from_server(
                 }
             ),
             ResultRecord(
+                id=ObjectId("1"),
                 program="psi4",
                 driver=DriverEnum.gradient,
                 method="scf",
@@ -278,6 +254,7 @@ def test_collection_from_server(
             ),
             OptimizationRecord(
                 program="psi4",
+                id=ObjectId("1"),
                 qc_spec=QCSpecification(
                     driver=DriverEnum.gradient,
                     method="scf",
@@ -291,6 +268,9 @@ def test_collection_from_server(
     ],
 )
 def test_to_results(collection, record, monkeypatch):
+
+    clear_results_caches()
+
     def mock_query_procedures(*args, **kwargs):
         return [record]
 

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -16,7 +16,6 @@ from openff.qcsubmit.results import (
     OptimizationResultCollection,
     TorsionDriveResultCollection,
 )
-from openff.qcsubmit.results.caching import clear_results_caches
 from openff.qcsubmit.results.filters import ResultFilter
 from openff.qcsubmit.results.results import OptimizationResult, _BaseResultCollection
 from openff.qcsubmit.tests import does_not_raise
@@ -268,8 +267,6 @@ def test_collection_from_server(
     ],
 )
 def test_to_results(collection, record, monkeypatch):
-
-    clear_results_caches()
 
     def mock_query_procedures(*args, **kwargs):
         return [record]


### PR DESCRIPTION
## Description

This PR adds a number of helper methods which enable caching queries to a `QCFractal` instance, as well as retrieving the records associated with a result collection.

These changes will likely be superseded by https://github.com/MolSSI/QCFractal/pull/671 (or its successors) when ready.

## Status
- [X] Ready to go