### PR TITLE
Make `openmmforcefields` an optional dependency

### DIFF
--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -357,8 +357,18 @@ class QCSpec(ResultsConfig):
             from openmmforcefields.generators.template_generators import (
                 GAFFTemplateGenerator,
             )
+
+            gaff_forcefields = GAFFTemplateGenerator.INSTALLED_FORCEFIELDS
+
         except ModuleNotFoundError:
-            GAFFTemplateGenerator = None
+
+            gaff_forcefields = [
+                "gaff-1.4",
+                "gaff-1.8",
+                "gaff-1.81",
+                "gaff-2.1",
+                "gaff-2.11",
+            ]
 
         # set up the valid method basis and program combinations
         ani_methods = {"ani1x", "ani1ccx", "ani2x"}
@@ -366,11 +376,10 @@ class QCSpec(ResultsConfig):
             ff.split(".offxml")[0].lower() for ff in get_available_force_fields()
         )
 
-        openmm_forcefields = {"smirnoff": openff_forcefields}
-
-        if GAFFTemplateGenerator is not None:
-            gaff_forcefields = GAFFTemplateGenerator.INSTALLED_FORCEFIELDS
-            openmm_forcefields["antechamber"] = gaff_forcefields
+        openmm_forcefields = {
+            "smirnoff": openff_forcefields,
+            "antechamber": gaff_forcefields,
+        }
 
         xtb_methods = {
             "gfn0-xtb",

--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -352,16 +352,26 @@ class QCSpec(ResultsConfig):
         Validate the combination of method, basis and program.
         """
         from openff.toolkit.typing.engines.smirnoff import get_available_force_fields
-        from openmmforcefields.generators.template_generators import (
-            GAFFTemplateGenerator,
-        )
+
+        try:
+            from openmmforcefields.generators.template_generators import (
+                GAFFTemplateGenerator,
+            )
+        except ModuleNotFoundError:
+            GAFFTemplateGenerator = None
 
         # set up the valid method basis and program combinations
         ani_methods = {"ani1x", "ani1ccx", "ani2x"}
         openff_forcefields = list(
             ff.split(".offxml")[0].lower() for ff in get_available_force_fields()
         )
-        gaff_forcefields = GAFFTemplateGenerator.INSTALLED_FORCEFIELDS
+
+        openmm_forcefields = {"smirnoff": openff_forcefields}
+
+        if GAFFTemplateGenerator is not None:
+            gaff_forcefields = GAFFTemplateGenerator.INSTALLED_FORCEFIELDS
+            openmm_forcefields["antechamber"] = gaff_forcefields
+
         xtb_methods = {
             "gfn0-xtb",
             "gfn0xtb",
@@ -374,7 +384,7 @@ class QCSpec(ResultsConfig):
         }
         rdkit_methods = {"uff", "mmff94", "mmff94s"}
         settings = {
-            "openmm": {"antechamber": gaff_forcefields, "smirnoff": openff_forcefields},
+            "openmm": openmm_forcefields,
             "torchani": {None: ani_methods},
             "xtb": {None: xtb_methods},
             "rdkit": {None: rdkit_methods},


### PR DESCRIPTION
## Description
This PR make `openmmforcefields` an optional dependency. This removes the second-hand `ambertools` dependency of this package and makes it easier to install alongside `psi4` when GAFF isn't needed.

## Status
- [X] Ready to go