### PR TITLE
Add base class for result record filters

### DIFF
--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -3,7 +3,12 @@ import logging
 import pytest
 from pydantic import ValidationError
 
-from openff.qcsubmit.results.filters import ResultFilter, SMARTSFilter, SMILESFilter
+from openff.qcsubmit.results.filters import (
+    ResultFilter,
+    ResultRecordFilter,
+    SMARTSFilter,
+    SMILESFilter,
+)
 
 
 def test_apply_filter(basic_result_collection, caplog):
@@ -26,6 +31,19 @@ def test_apply_filter(basic_result_collection, caplog):
 
     assert "applied-filters" in filtered_collection.provenance
     assert "DummyFilter-0" in filtered_collection.provenance["applied-filters"]
+
+
+def test_apply_record_filter(basic_result_collection):
+    class DummyFilter(ResultRecordFilter):
+        def _filter_function(self, result, record, molecule) -> bool:
+            return record.client.address == "http://localhost:442"
+
+    filtered_collection = DummyFilter().apply(basic_result_collection)
+
+    assert filtered_collection.n_results == 4
+
+    assert "http://localhost:442" in filtered_collection.entries
+    assert "http://localhost:443" not in filtered_collection.entries
 
 
 def test_smiles_filter_mutual_inputs():


### PR DESCRIPTION
## Description

This PR adds a new `ResultRecordFilter` base class for new filters which will filter based information contained in records themselves, rather than just based on a record id or CMILES / InChI. The filter handles all of the batched record retrievals and only requires sub-filters to define a method to either retain or reject a result based on it's corresponding record.

## Status
- [X] Ready to go