### PR TITLE
Add h-bond and connectivity results filters

### DIFF
--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -1,9 +1,16 @@
 import logging
 
 import pytest
+from openff.toolkit.topology import Molecule
 from pydantic import ValidationError
+from qcelemental.models import DriverEnum
+from qcportal.models import ObjectId, ResultRecord
+from qcportal.models.records import RecordStatusEnum
 
+from openff.qcsubmit.results import BasicResult
 from openff.qcsubmit.results.filters import (
+    ConnectivityFilter,
+    HydrogenBondFilter,
     ResultFilter,
     ResultRecordFilter,
     SMARTSFilter,
@@ -90,3 +97,104 @@ def test_molecule_filter_apply(result_filter, expected_ids, basic_result_collect
         assert entry_ids == {
             entry.record_id for entry in filtered_collection.entries[address]
         }
+
+
+@pytest.mark.parametrize(
+    "result_filter, expected_ids",
+    [
+        (
+            HydrogenBondFilter(method="baker-hubbard"),
+            {"http://localhost:443": {"1"}},
+        ),
+    ],
+)
+def test_basic_record_filter_apply(
+    result_filter, expected_ids, h_bond_basic_result_collection
+):
+
+    filtered_collection = result_filter.apply(h_bond_basic_result_collection)
+
+    assert {*expected_ids} == {*filtered_collection.entries}
+
+    for address, entry_ids in expected_ids.items():
+
+        assert entry_ids == {
+            entry.record_id for entry in filtered_collection.entries[address]
+        }
+
+
+@pytest.mark.parametrize(
+    "result_filter, expected_ids",
+    [
+        (
+            HydrogenBondFilter(method="baker-hubbard"),
+            {"http://localhost:442": {"1", "2", "3", "4"}},
+        ),
+    ],
+)
+def test_optimization_record_filter_apply(
+    result_filter, expected_ids, optimization_result_collection
+):
+
+    filtered_collection = result_filter.apply(optimization_result_collection)
+
+    assert {*expected_ids} == {*filtered_collection.entries}
+
+    for address, entry_ids in expected_ids.items():
+
+        assert entry_ids == {
+            entry.record_id for entry in filtered_collection.entries[address]
+        }
+
+
+@pytest.mark.parametrize(
+    "result_filter, expected_ids",
+    [
+        (HydrogenBondFilter(method="baker-hubbard"), {"http://localhost:443": {"1"}}),
+    ],
+)
+def test_torsion_drive_record_filter_apply(
+    result_filter, expected_ids, torsion_drive_result_collection
+):
+
+    filtered_collection = result_filter.apply(torsion_drive_result_collection)
+
+    assert {*expected_ids} == {*filtered_collection.entries}
+
+    for address, entry_ids in expected_ids.items():
+
+        assert entry_ids == {
+            entry.record_id for entry in filtered_collection.entries[address]
+        }
+
+
+def test_connectivity_filter():
+
+    result = BasicResult(
+        record_id=ObjectId("1"),
+        cmiles="[Cl:1][Cl:2]",
+        inchi_key="KZBUYRJDOAKODT-UHFFFAOYSA-N",
+    )
+    record = ResultRecord(
+        id=ObjectId("1"),
+        program="psi4",
+        driver=DriverEnum.gradient,
+        method="scf",
+        basis="sto-3g",
+        molecule=ObjectId("1"),
+        status=RecordStatusEnum.complete,
+    )
+
+    connectivity_filter = ConnectivityFilter()
+
+    molecule: Molecule = Molecule.from_smiles("[Cl:1][Cl:2]")
+    molecule.generate_conformers(n_conformers=1)
+
+    assert connectivity_filter._filter_function(result, record, molecule)
+
+    molecule.conformers[0] *= 10.0
+
+    assert not connectivity_filter._filter_function(result, record, molecule)
+
+    connectivity_filter.tolerance = 12.01  # default * 10.0 + 0.01
+    assert connectivity_filter._filter_function(result, record, molecule)


### PR DESCRIPTION
## Description

This PR adds two new filters:

* `HydrogenBondFilter` - filters out hydrogen bond containing records
* `ConnectivityFilter` - filters out records where the final and initial molecules have different connectivities

## Status
- [X] Ready to go