### PR TITLE
Add record status result filter

### DIFF
--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -7,7 +7,7 @@ import numpy
 from openff.toolkit.topology import Molecule
 from pydantic import BaseModel, Field, PrivateAttr, root_validator
 from qcelemental.molutil import guess_connectivity
-from qcportal.models.records import RecordBase
+from qcportal.models.records import RecordBase, RecordStatusEnum
 from simtk import unit
 from typing_extensions import Literal
 
@@ -360,3 +360,20 @@ class ConnectivityFilter(ResultRecordFilter):
             return False
 
         return True
+
+
+class RecordStatusFilter(ResultRecordFilter):
+    """A filter which will only retain records if their status matches a specified
+    value.
+    """
+
+    status: RecordStatusEnum = Field(
+        RecordStatusEnum.complete,
+        description="Records whose status match this value will be retained.",
+    )
+
+    def _filter_function(
+        self, result: "_BaseResult", record: RecordBase, molecule: Molecule
+    ) -> bool:
+
+        return record.status.value.upper() == self.status.value.upper()

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -12,6 +12,7 @@ from openff.qcsubmit.results.filters import (
     CMILESResultFilter,
     ConnectivityFilter,
     HydrogenBondFilter,
+    RecordStatusFilter,
     ResultFilter,
     ResultRecordFilter,
     SMARTSFilter,
@@ -218,3 +219,22 @@ def test_connectivity_filter():
 
     connectivity_filter.tolerance = 12.01  # default * 10.0 + 0.01
     assert connectivity_filter._filter_function(result, record, molecule)
+
+
+def test_record_status_filter():
+
+    record = ResultRecord(
+        id=ObjectId("1"),
+        program="psi4",
+        driver=DriverEnum.gradient,
+        method="scf",
+        basis="sto-3g",
+        molecule=ObjectId("1"),
+        status=RecordStatusEnum.complete,
+    )
+
+    status_filter = RecordStatusFilter(status=RecordStatusEnum.complete)
+    assert status_filter._filter_function(None, record, None) is True
+
+    status_filter = RecordStatusFilter(status=RecordStatusEnum.incomplete)
+    assert status_filter._filter_function(None, record, None) is False


### PR DESCRIPTION
## Description

This PR adds a `RecordStatusFilter` filter which will only retain records whose status matches a specified value.

## Status
- [X] Ready to go