### PR TITLE
Make `qcfractal` an optional import

### DIFF
--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -12,7 +12,6 @@ import qcportal as ptl
 from pydantic import BaseModel, Field, HttpUrl, PositiveInt, constr, validator
 from qcelemental import constants
 from qcelemental.models.results import WavefunctionProtocolEnum
-from qcfractal.interface import FractalClient
 from qcportal.models.common_models import DriverEnum
 
 from openff.qcsubmit.exceptions import (
@@ -960,9 +959,14 @@ class ClientHandler:
             A qcportal.FractalClient instance.
         """
 
+        try:
+            from qcfractal.interface import FractalClient as QCFractalClient
+        except ModuleNotFoundError:
+            QCFractalClient = None
+
         if isinstance(client, ptl.FractalClient):
             return client
-        elif isinstance(client, FractalClient):
+        elif QCFractalClient is not None and isinstance(client, QCFractalClient):
             return client
         elif client == "public":
             return ptl.FractalClient()

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -1,13 +1,22 @@
 import json
 import os
-from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import qcelemental as qcel
 import qcportal as ptl
 import tqdm
 from openff.toolkit import topology as off
 from pydantic import Field, constr, validator
-from qcfractal.interface import FractalClient
 from qcportal.models.common_models import (
     DriverEnum,
     OptimizationSpecification,
@@ -39,6 +48,9 @@ from openff.qcsubmit.exceptions import (
 from openff.qcsubmit.procedures import GeometricProcedure
 from openff.qcsubmit.serializers import deserialize, serialize
 from openff.qcsubmit.utils import chunk_generator
+
+if TYPE_CHECKING:
+    from qcfractal.interface import FractalClient
 
 
 class ComponentResult:
@@ -719,7 +731,7 @@ class BasicDataset(CommonBase):
 
     def submit(
         self,
-        client: Union[str, ptl.FractalClient, FractalClient],
+        client: Union[str, ptl.FractalClient, "FractalClient"],
         threads: Optional[int] = None,
         ignore_errors: bool = False,
         verbose: bool = False,
@@ -1367,7 +1379,7 @@ class OptimizationDataset(BasicDataset):
 
     def submit(
         self,
-        client: Union[str, ptl.FractalClient, FractalClient],
+        client: Union[str, ptl.FractalClient, "FractalClient"],
         threads: Optional[int] = None,
         ignore_errors: bool = False,
         verbose: bool = False,
@@ -1625,7 +1637,7 @@ class TorsiondriveDataset(OptimizationDataset):
 
     def submit(
         self,
-        client: Union[str, ptl.FractalClient, FractalClient],
+        client: Union[str, ptl.FractalClient, "FractalClient"],
         threads: Optional[int] = None,
         ignore_errors: bool = False,
         verbose: bool = False,


### PR DESCRIPTION
## Description

This PR ensures that `qcfractal` is an optional import and hence can be made an optional dependency. In most cases it seems like only `qcportal` should be required which is a much lighter package.

## Status
- [X] Ready to go