### PR TITLE
Add fixed hydrogen inchi/inchikey to attributes

### DIFF
--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -9,6 +9,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import qcportal as ptl
+from openff.toolkit.topology import Molecule
 from pydantic import BaseModel, Field, HttpUrl, PositiveInt, constr, validator
 from qcelemental import constants
 from qcelemental.models.results import WavefunctionProtocolEnum
@@ -1065,7 +1066,7 @@ class MoleculeAttributes(DatasetConfig):
     )
 
     @classmethod
-    def from_openff_molecule(cls, molecule) -> "MoleculeAttributes":
+    def from_openff_molecule(cls, molecule: Molecule) -> "MoleculeAttributes":
         """Create the Cmiles metadata for an OpenFF molecule object.
 
         Parameters:
@@ -1109,10 +1110,19 @@ class MoleculeAttributes(DatasetConfig):
             "standard_inchi": molecule.to_inchi(fixed_hydrogens=False),
             "inchi_key": molecule.to_inchikey(fixed_hydrogens=False),
             "fixed_hydrogen_inchi": molecule.to_inchi(fixed_hydrogens=True),
-            "fixed_hydrogen_inchi_key": molecule.to_inchikey(fixed_hydrogens=True)
+            "fixed_hydrogen_inchi_key": molecule.to_inchikey(fixed_hydrogens=True),
         }
 
         return MoleculeAttributes(**cmiles)
+
+    def to_openff_molecule(self) -> Molecule:
+        """
+        Create an openff molecule from the CMILES information.
+        """
+        return Molecule.from_mapped_smiles(
+            mapped_smiles=self.canonical_isomeric_explicit_hydrogen_mapped_smiles,
+            allow_undefined_stereo=True,
+        )
 
 
 class SCFProperties(str, Enum):

--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -1056,6 +1056,13 @@ class MoleculeAttributes(DatasetConfig):
     inchi_key: str = Field(
         ..., description="The standard inchi key given by the inchi program."
     )
+    fixed_hydrogen_inchi: str = Field(
+        ...,
+        description="The non-standard inchi with a fixed hydrogen layer to distinguish tautomers.",
+    )
+    fixed_hydrogen_inchi_key: str = Field(
+        ..., description="The non-standard inchikey with a fixed hydrogen layer."
+    )
 
     @classmethod
     def from_openff_molecule(cls, molecule) -> "MoleculeAttributes":
@@ -1078,6 +1085,8 @@ class MoleculeAttributes(DatasetConfig):
             - `molecular_formula`
             - `standard_inchi`
             - `inchi_key`
+            - `fixed_hydrogen_inchi`
+            - `fixed_hydrogen_inchi_key`
         """
 
         cmiles = {
@@ -1099,6 +1108,8 @@ class MoleculeAttributes(DatasetConfig):
             "molecular_formula": molecule.hill_formula,
             "standard_inchi": molecule.to_inchi(fixed_hydrogens=False),
             "inchi_key": molecule.to_inchikey(fixed_hydrogens=False),
+            "fixed_hydrogen_inchi": molecule.to_inchi(fixed_hydrogens=True),
+            "fixed_hydrogen_inchi_key": molecule.to_inchikey(fixed_hydrogens=True)
         }
 
         return MoleculeAttributes(**cmiles)

--- a/openff/qcsubmit/data/invalid_double_torsion_dataset.json
+++ b/openff/qcsubmit/data/invalid_double_torsion_dataset.json
@@ -146,7 +146,9 @@
         "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[H:4][C:1]([H:5])([H:6])[C:2]([H:7])([H:8])[O:3][H:9]",
         "molecular_formula": "C2H6O",
         "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
-        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N"
+        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
+        "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        "fixed_hydrogen_inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYNA-N"
       },
       "dihedrals": [
         [

--- a/openff/qcsubmit/data/invalid_improper_dataset.json
+++ b/openff/qcsubmit/data/invalid_improper_dataset.json
@@ -146,7 +146,9 @@
         "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[H:4][C:1]([H:5])([H:6])[C:2]([H:7])([H:8])[O:3][H:9]",
         "molecular_formula": "C2H6O",
         "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
-        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N"
+        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
+        "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        "fixed_hydrogen_inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYNA-N"
       },
       "dihedrals": [
         [

--- a/openff/qcsubmit/data/invalid_linear_dataset.json
+++ b/openff/qcsubmit/data/invalid_linear_dataset.json
@@ -450,7 +450,9 @@
         "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[H:29][c:2]1[c:3]([c:10]([c:14]([c:13]([c:4]1[H:31])[Cl:27])[Cl:28])[C:17]2=[N:23][C:15]3=[C:12]([C:9](=[N:22][N:24]3[C:18](=[C:16]2[H:37])[N:25]([H:40])[C:19]([H:38])([H:39])[c:11]4[c:5]([c:7]([n:21][c:8]([c:6]4[H:33])[H:35])[H:34])[H:32])[H:36])[S:26][C:1]#[N:20])[H:30]",
         "molecular_formula": "C19H12Cl2N6S",
         "standard_inchi": "InChI=1S/C19H12Cl2N6S/c20-14-3-1-2-13(18(14)21)15-8-17(24-9-12-4-6-23-7-5-12)27-19(26-15)16(10-25-27)28-11-22/h1-8,10,24H,9H2",
-        "inchi_key": "AHPKUZJCNHGFQA-UHFFFAOYSA-N"
+        "inchi_key": "AHPKUZJCNHGFQA-UHFFFAOYSA-N",
+        "fixed_hydrogen_inchi": "InChI=1/C19H12Cl2N6S/c20-14-3-1-2-13(18(14)21)15-8-17(24-9-12-4-6-23-7-5-12)27-19(26-15)16(10-25-27)28-11-22/h1-8,10,24H,9H2",
+        "fixed_hydrogen_inchi_key": "AHPKUZJCNHGFQA-UHFFFAOYNA-N"
       },
       "dihedrals": [
         [

--- a/openff/qcsubmit/data/invalid_torsion_dataset.json
+++ b/openff/qcsubmit/data/invalid_torsion_dataset.json
@@ -146,7 +146,9 @@
         "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[H:4][C:1]([H:5])([H:6])[C:2]([H:7])([H:8])[O:3][H:9]",
         "molecular_formula": "C2H6O",
         "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
-        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N"
+        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
+        "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        "fixed_hydrogen_inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYNA-N"
       },
       "dihedrals": [
         [

--- a/openff/qcsubmit/data/valid_double_torsion_dataset.json
+++ b/openff/qcsubmit/data/valid_double_torsion_dataset.json
@@ -146,7 +146,9 @@
         "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[H:4][C:1]([H:5])([H:6])[C:2]([H:7])([H:8])[O:3][H:9]",
         "molecular_formula": "C2H6O",
         "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
-        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N"
+        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
+        "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        "fixed_hydrogen_inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYNA-N"
       },
       "dihedrals": [
         [

--- a/openff/qcsubmit/data/valid_improper_dataset.json
+++ b/openff/qcsubmit/data/valid_improper_dataset.json
@@ -146,7 +146,9 @@
         "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[H:4][C:1]([H:5])([H:6])[C:2]([H:7])([H:8])[O:3][H:9]",
         "molecular_formula": "C2H6O",
         "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
-        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N"
+        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
+        "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        "fixed_hydrogen_inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYNA-N"
       },
       "dihedrals": [
         [

--- a/openff/qcsubmit/data/valid_torsion_dataset.json
+++ b/openff/qcsubmit/data/valid_torsion_dataset.json
@@ -146,7 +146,9 @@
         "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[H:4][C:1]([H:5])([H:6])[C:2]([H:7])([H:8])[O:3][H:9]",
         "molecular_formula": "C2H6O",
         "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
-        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N"
+        "inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
+        "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        "fixed_hydrogen_inchi_key": "LFQSCWFLJHTTHZ-UHFFFAOYNA-N"
       },
       "dihedrals": [
         [

--- a/openff/qcsubmit/datasets/entries.py
+++ b/openff/qcsubmit/datasets/entries.py
@@ -103,10 +103,7 @@ class DatasetEntry(DatasetConfig):
             include_conformers: If `True` all of the input conformers are included else they are dropped.
         """
 
-        molecule = off.Molecule.from_mapped_smiles(
-            mapped_smiles=self.attributes.canonical_isomeric_explicit_hydrogen_mapped_smiles,
-            allow_undefined_stereo=True,
-        )
+        molecule = self.attributes.to_openff_molecule()
         molecule.name = self.index
         if include_conformers:
             for conformer in self.initial_molecules:

--- a/openff/qcsubmit/tests/test_common_structures.py
+++ b/openff/qcsubmit/tests/test_common_structures.py
@@ -27,3 +27,18 @@ def test_attributes_from_openff_molecule():
         "fixed_hydrogen_inchi_key": mol.to_inchikey(fixed_hydrogens=True)
     }
     assert test_cmiles == attributes
+
+
+def test_attributes_to_openff_molecule():
+    """Round trip a molecule to and from its attributes."""
+
+    mol: Molecule = Molecule.from_smiles("CC")
+
+    attributes = MoleculeAttributes.from_openff_molecule(molecule=mol)
+
+    mol2 = attributes.to_openff_molecule()
+
+    isomorphic, atom_map = Molecule.are_isomorphic(mol, mol2, return_atom_map=True)
+    assert isomorphic is True
+    # make sure the molecules are in the same order
+    assert atom_map == dict((i, i) for i in range(mol.n_atoms))

--- a/openff/qcsubmit/tests/test_common_structures.py
+++ b/openff/qcsubmit/tests/test_common_structures.py
@@ -23,5 +23,7 @@ def test_attributes_from_openff_molecule():
         "molecular_formula": mol.hill_formula,
         "standard_inchi": mol.to_inchi(fixed_hydrogens=False),
         "inchi_key": mol.to_inchikey(fixed_hydrogens=False),
+        "fixed_hydrogen_inchi": mol.to_inchi(fixed_hydrogens=True),
+        "fixed_hydrogen_inchi_key": mol.to_inchikey(fixed_hydrogens=True)
     }
     assert test_cmiles == attributes

--- a/openff/qcsubmit/tests/test_factories.py
+++ b/openff/qcsubmit/tests/test_factories.py
@@ -403,17 +403,12 @@ def test_torsiondrive_factory_index():
     assert index == mol.to_smiles(isomeric=True, explicit_hydrogens=True, mapped=True)
 
 
-@pytest.mark.parametrize("factory_type", [
-    pytest.param(BasicDatasetFactory, id="BasicDatasetFactory"),
-    pytest.param(OptimizationDatasetFactory, id="OptimizationDatasetFactory"),
-    pytest.param(TorsiondriveDatasetFactory, id="TorsiondriveDatasetFactory")
-])
-def test_factory_cmiles(factory_type):
+def test_factory_cmiles():
     """
     Test the basic factories ability to make cmiles attributes for the molecules.
     """
 
-    factory = factory_type()
+    factory = BasicDatasetFactory()
     mol = Molecule.from_smiles("CC")
 
     cmiles_factory = factory.create_cmiles_metadata(mol)
@@ -432,6 +427,8 @@ def test_factory_cmiles(factory_type):
         "molecular_formula": mol.hill_formula,
         "standard_inchi": mol.to_inchi(fixed_hydrogens=False),
         "inchi_key": mol.to_inchikey(fixed_hydrogens=False),
+        "fixed_hydrogen_inchi": mol.to_inchi(fixed_hydrogens=True),
+        "fixed_hydrogen_inchi_key": mol.to_inchikey(fixed_hydrogens=True),
     }
     assert test_cmiles == cmiles_factory
 


### PR DESCRIPTION
## Description
We often use fixed hydrogen inchi key for fast deduplication, this PR adds the fixed hydrogen inchi and inchikey to the `MoleculeAttributes` object, these fields are automatically generated still via the `from_openff_molecule` classmethod. A convenient method to generate an openff molecule from the MoleculeAttributes is also added called `to_openff_molecule`.