### PR TITLE
Fix stereochemistry error when creating molecule from SMILES

### DIFF
--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -186,7 +186,9 @@ class SMILESFilter(CMILESResultFilter):
 
     @staticmethod
     def _smiles_to_inchi_key(smiles: str) -> str:
-        return Molecule.from_smiles(smiles).to_inchikey(fixed_hydrogens=False)
+        return Molecule.from_smiles(smiles, allow_undefined_stereo=True).to_inchikey(
+            fixed_hydrogens=False
+        )
 
     def _filter_function(self, entry: "_BaseResult") -> bool:
 
@@ -252,7 +254,9 @@ class SMARTSFilter(CMILESResultFilter):
 
     def _filter_function(self, entry: "_BaseResult") -> bool:
 
-        molecule: Molecule = Molecule.from_mapped_smiles(entry.cmiles)
+        molecule: Molecule = Molecule.from_mapped_smiles(
+            entry.cmiles, allow_undefined_stereo=True
+        )
 
         if self.smarts_to_include is not None:
 

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -72,7 +72,7 @@ class _BaseResult(BaseModel, abc.ABC):
         """Returns an OpenFF molecule object created from this records
         CMILES which is in the correct order to align with the QCArchive records.
         """
-        return Molecule.from_mapped_smiles(self.cmiles)
+        return Molecule.from_mapped_smiles(self.cmiles, allow_undefined_stereo=True)
 
 
 class _BaseResultCollection(BaseModel, abc.ABC):


### PR DESCRIPTION
## Description

This PR fixes issues when creating molecules from SMILES patterns whose stereochemistry is not fully defined in the CMILES (e.g. cases where OE thinks a N is a stereocenter but RDKit does not).

## Status
- [X] Ready to go