### PR TITLE
Fix key error when entry not in result query

### DIFF
--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -541,7 +541,8 @@ class TorsionDriveResultCollection(_BaseResultCollection):
                         inchi_key=entry.attributes["inchi_key"],
                     )
                     for entry in dataset.data.records.values()
-                    if query[entry.name].status.value.upper() == "COMPLETE"
+                    if entry.name in query
+                    and query[entry.name].status.value.upper() == "COMPLETE"
                 }
             )
 

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -411,7 +411,8 @@ class OptimizationResultCollection(_BaseResultCollection):
                         inchi_key=entry.attributes["inchi_key"],
                     )
                     for entry in dataset.data.records.values()
-                    if query[entry.name].status.value.upper() == "COMPLETE"
+                    if entry.name in query
+                    and query[entry.name].status.value.upper() == "COMPLETE"
                 }
             )
 


### PR DESCRIPTION
## Description

This PR fixes a key error raised when creating a result collection from a data set. This occurs when the dataset contains an entry not present in the query for a given spec name.

## Status
- [X] Ready to go