### PR TITLE
Add optimization result collection to basic result collection

### DIFF
--- a/openff/qcsubmit/results/caching.py
+++ b/openff/qcsubmit/results/caching.py
@@ -45,7 +45,7 @@ def clear_results_caches():
     _grid_id_cache.clear()
 
 
-def _batched_indices(indices: List[T], batch_size: int) -> List[List[T]]:
+def batched_indices(indices: List[T], batch_size: int) -> List[List[T]]:
     """Split a list of indices into batches.
 
     Args:
@@ -59,7 +59,7 @@ def _batched_indices(indices: List[T], batch_size: int) -> List[List[T]]:
 
 
 @lru_cache()
-def _cached_fractal_client(address: str) -> FractalClient:
+def cached_fractal_client(address: str) -> FractalClient:
     """Returns a cached copy of a fractal client."""
     return FractalClient(address)
 
@@ -102,11 +102,11 @@ def _cached_client_query(
         if (client_address, query_id) in query_cache
     ]
 
-    client = _cached_fractal_client(client_address)
+    client = cached_fractal_client(client_address)
 
     logger.debug(f"starting {query_name} to {client_address}")
 
-    batch_query_ids = _batched_indices(missing_query_ids, client.query_limit)
+    batch_query_ids = batched_indices(missing_query_ids, client.query_limit)
     logger.debug(f"query split into {len(batch_query_ids)} batches")
 
     for i, batch_ids in enumerate(batch_query_ids):
@@ -290,9 +290,9 @@ def _cached_torsion_drive_molecule_ids(
         if (client_address, *grid_tuple) not in _grid_id_cache
     }
 
-    client = _cached_fractal_client(client_address)
+    client = cached_fractal_client(client_address)
 
-    batched_missing_ids = _batched_indices(
+    batched_missing_ids = batched_indices(
         [*missing_optimization_ids.values()], client.query_limit
     )
 

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -471,7 +471,8 @@ class OptimizationResultCollection(_BaseResultCollection):
     ) -> BasicResultCollection:
         """Returns a basic results collection which references results records which
         were created from the *final* structure of one of the optimizations in this
-        collection.
+        collection, and used the same program, method, and basis as the parent
+        optimization record.
 
         Args:
             driver: Optionally specify the driver to filter by.

--- a/openff/qcsubmit/tests/results/__init__.py
+++ b/openff/qcsubmit/tests/results/__init__.py
@@ -120,6 +120,7 @@ def mock_optimization_result_collection(
                         program="psi4",
                     ),
                     initial_molecule=ObjectId(entry.record_id),
+                    final_molecule=ObjectId(entry.record_id),
                     status=RecordStatusEnum.complete,
                     client=_FractalClient(address=address),
                 ),

--- a/openff/qcsubmit/tests/results/test_caching.py
+++ b/openff/qcsubmit/tests/results/test_caching.py
@@ -9,10 +9,10 @@ from simtk import unit
 
 from openff.qcsubmit.results import BasicResult, OptimizationResult, TorsionDriveResult
 from openff.qcsubmit.results.caching import (
-    _batched_indices,
     _grid_id_cache,
     _molecule_cache,
     _record_cache,
+    batched_indices,
     cached_query_basic_results,
     cached_query_molecules,
     cached_query_optimization_results,
@@ -22,7 +22,7 @@ from openff.qcsubmit.results.caching import (
 
 
 def test_batched_indices():
-    assert _batched_indices([1, 2, 3, 4], 3) == [[1, 2, 3], [4]]
+    assert batched_indices([1, 2, 3, 4], 3) == [[1, 2, 3], [4]]
 
 
 def test_cached_query_procedures(public_client):

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -355,20 +355,27 @@ def test_to_records(collection, record, monkeypatch):
         assert molecule.n_conformers == 1
 
 
-def test_to_optimization_to_basic_dataset(optimization_result_collection, monkeypatch):
+def test_optimization_to_basic_result_collection(
+    optimization_result_collection, monkeypatch
+):
 
     def mock_automodel_request(*args, **kwargs):
         return MockServerInfo()
 
     def mock_query_results(*args, **kwargs):
 
+        assert "program" in kwargs and kwargs["program"] == "psi4"
+        assert "method" in kwargs and kwargs["method"] == "scf"
+        assert "basis" in kwargs and kwargs["basis"] == "sto-3g"
+        assert "driver" in kwargs and kwargs["driver"] == "hessian"
+
         return [
             ResultRecord(
                 id=ObjectId("1"),
-                program="psi4",
+                program=kwargs["program"],
                 driver=getattr(DriverEnum, kwargs["driver"]),
-                method="scf",
-                basis="sto-3g",
+                method=kwargs["method"],
+                basis=kwargs["basis"],
                 molecule=kwargs["molecule"][0],
                 status=RecordStatusEnum.complete,
             )
@@ -377,7 +384,9 @@ def test_to_optimization_to_basic_dataset(optimization_result_collection, monkey
     monkeypatch.setattr(FractalClient, "_automodel_request", mock_automodel_request)
     monkeypatch.setattr(FractalClient, "query_results", mock_query_results)
 
-    basic_collection = optimization_result_collection.to_basic_collection("hessian")
+    basic_collection = optimization_result_collection.to_basic_result_collection(
+        "hessian"
+    )
 
     assert basic_collection.n_results == 2
     assert basic_collection.n_molecules == 2

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -38,6 +38,18 @@ from openff.qcsubmit.results.results import (
 from openff.qcsubmit.tests import does_not_raise
 
 
+class MockServerInfo:
+
+    def dict(self):
+        return {
+            "name": "Mock",
+            "query_limit": 2000,
+            "version": "0.0.0",
+            "client_lower_version_limit": "0.0.0",
+            "client_upper_version_limit": "10.0.0",
+        }
+
+
 def test_base_molecule_property():
 
     record = BasicResult(
@@ -341,6 +353,34 @@ def test_to_records(collection, record, monkeypatch):
 
     if not isinstance(record, TorsionDriveRecord):
         assert molecule.n_conformers == 1
+
+
+def test_to_optimization_to_basic_dataset(optimization_result_collection, monkeypatch):
+
+    def mock_automodel_request(*args, **kwargs):
+        return MockServerInfo()
+
+    def mock_query_results(*args, **kwargs):
+
+        return [
+            ResultRecord(
+                id=ObjectId("1"),
+                program="psi4",
+                driver=getattr(DriverEnum, kwargs["driver"]),
+                method="scf",
+                basis="sto-3g",
+                molecule=kwargs["molecule"][0],
+                status=RecordStatusEnum.complete,
+            )
+        ]
+
+    monkeypatch.setattr(FractalClient, "_automodel_request", mock_automodel_request)
+    monkeypatch.setattr(FractalClient, "query_results", mock_query_results)
+
+    basic_collection = optimization_result_collection.to_basic_collection("hessian")
+
+    assert basic_collection.n_results == 2
+    assert basic_collection.n_molecules == 2
 
 
 # def test_optimization_create_basic_dataset(public_client):


### PR DESCRIPTION
## Description
This PR adds a convenience method to create a basic data set collection from an existing optimization result collection. This would allow, for example, being able to find all of the hessian result records which were generated using the final structure of a set of optimizations.

This may be preferable in certain cases to just creating the basic result collection itself. This is especially true when trying to create a result collection from an older dataset which does not have CMILES information attached. This method will propagate the parent optimization CMILES down to the child basic result record thus circumventing this issue.

## Status
- [x] Ready to go