### PR TITLE
Rotor update

### DIFF
--- a/openff/qcsubmit/tests/test_workflow_components.py
+++ b/openff/qcsubmit/tests/test_workflow_components.py
@@ -730,9 +730,9 @@ def test_fragmentation_apply():
         assert "dihedrals" in molecule.properties
 
 
-def test_rotor_filter_pass():
+def test_rotor_filter_maximum():
     """
-    Make sure the rotor filter removes the correct molecules.
+    Remove molecules with too many rotatable bonds.
     """
 
     rotor_filter = workflow_components.RotorFilter()
@@ -745,6 +745,24 @@ def test_rotor_filter_pass():
     result = rotor_filter.apply(molecule_container.molecules, processors=1)
     for molecule in result.molecules:
         assert len(molecule.find_rotatable_bonds()) <= rotor_filter.maximum_rotors
+
+
+def test_rotor_filter_minimum():
+    """
+    Remove molecules with too few rotatable bonds.
+    """
+    rotor_filter = workflow_components.RotorFilter()
+    rotor_filter.minimum_rotors = 3
+    # not capped
+    rotor_filter.maximum_rotors = None
+
+    mols = get_tautomers()
+    mol_container = get_container(mols)
+    result = rotor_filter.apply(mol_container.molecules, processors=1)
+    for molecule in result.molecules:
+        assert len(molecule.find_rotatable_bonds()) >= rotor_filter.minimum_rotors
+    for molecule in result.filtered:
+        assert len(molecule.find_rotatable_bonds()) < rotor_filter.minimum_rotors
 
 
 def test_rotor_filter_fail():

--- a/openff/qcsubmit/tests/test_workflow_components.py
+++ b/openff/qcsubmit/tests/test_workflow_components.py
@@ -765,6 +765,22 @@ def test_rotor_filter_minimum():
         assert len(molecule.find_rotatable_bonds()) < rotor_filter.minimum_rotors
 
 
+def test_rotor_filter_validation():
+    """
+    Make sure that the maximum number of rotors is >= the minimum if defined.
+    """
+
+    rotor_filter = workflow_components.RotorFilter()
+    rotor_filter.maximum_rotors = 4
+    rotor_filter.minimum_rotors = 4
+    mols = get_tautomers()
+    mol_container = get_container(mols)
+    rotor_filter.apply(mol_container.molecules, processors=1)
+    rotor_filter.minimum_rotors = 5
+    with pytest.raises(ValueError):
+        rotor_filter.apply(mol_container.molecules, processors=1)
+
+
 def test_rotor_filter_fail():
     """
     Test filtering out molecules with too many rotatable bonds.

--- a/openff/qcsubmit/workflow_components/filters.py
+++ b/openff/qcsubmit/workflow_components/filters.py
@@ -348,6 +348,16 @@ class RotorFilter(BasicSettings, CustomWorkflowComponent):
         description="The minimum number of rotatble bonds allowed in the molecule, if `None` the molecule has no limit to the minimum number of rotatble bonds.",
     )
 
+    def _apply_init(self, result: ComponentResult) -> None:
+        """
+        Validate the choice of minimum and maximum rotators.
+        """
+        if self.maximum_rotors and self.minimum_rotors:
+            if self.maximum_rotors < self.minimum_rotors:
+                raise ValueError(
+                    "The maximum number of rotors should >= the minimum to ensure some molecules pass."
+                )
+
     def _apply(self, molecules: List[Molecule]) -> ComponentResult:
         """
         Apply the filter to the list of molecules to remove any molecules with more rotors then the maximum allowed


### PR DESCRIPTION
## Description
This PR implements a minimum rotatable bond option for the RotorFilter to finish PR #74.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] Add the option to also filter by the minimum number of rotatable bonds
  - [X] Raise an error if the maximum and minimum are defined but max < min and would result in no molecules.

## Status
- [X] Ready to go