### PR TITLE
Component/Factory update

### DIFF
--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -58,8 +58,14 @@ class ComponentProperties(BaseModel):
     produces duplicates.
     """
 
-    process_parallel: bool = True
-    produces_duplicates: bool = True
+    process_parallel: bool = Field(
+        ...,
+        description="If the component can safely be ran in parallel `True` or not `False`.",
+    )
+    produces_duplicates: bool = Field(
+        ...,
+        description="If the component is expected to produce duplicate molecules `True` or not `False`.",
+    )
 
     class Config:
         allow_mutation: bool = False

--- a/openff/qcsubmit/data/settings_with_workflow.json
+++ b/openff/qcsubmit/data/settings_with_workflow.json
@@ -21,7 +21,8 @@
       "component_fail_message": "Conformers could not be generated",
       "toolkit": "openeye",
       "max_conformers": 20,
-      "clear_existing": true
+      "clear_existing": true,
+      "type": "StandardConformerGenerator"
     }
   }
 }

--- a/openff/qcsubmit/data/settings_with_workflow.yaml
+++ b/openff/qcsubmit/data/settings_with_workflow.yaml
@@ -20,3 +20,4 @@ workflow:
     component_name: StandardConformerGenerator
     max_conformers: 20
     toolkit: openeye
+    type: StandardConformerGenerator

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -541,8 +541,8 @@ class BasicDataset(CommonBase):
     def filter_molecules(
         self,
         molecules: Union[off.Molecule, List[off.Molecule]],
-        component_name: str,
-        component_description: Dict[str, Any],
+        component: str,
+        component_settings: Dict[str, Any],
         component_provenance: Dict[str, str],
     ) -> None:
         """
@@ -551,9 +551,9 @@ class BasicDataset(CommonBase):
         Parameters:
         molecules:
             A molecule or list of molecules to be filtered.
-        component_description:
+        component_settings:
             The dictionary representation of the component that filtered this set of molecules.
-        component_name:
+        component:
             The name of the component.
         component_provenance:
             The dictionary representation of the component provenance.
@@ -563,22 +563,22 @@ class BasicDataset(CommonBase):
             # make into a list
             molecules = [molecules]
 
-        if component_name in self.filtered_molecules:
+        if component in self.filtered_molecules:
             filter_mols = [
                 molecule.to_smiles(isomeric=True, explicit_hydrogens=True)
                 for molecule in molecules
             ]
-            self.filtered_molecules[component_name].molecules.extend(filter_mols)
+            self.filtered_molecules[component].molecules.extend(filter_mols)
         else:
 
             filter_data = FilterEntry(
                 off_molecules=molecules,
-                component_name=component_name,
+                component=component,
                 component_provenance=component_provenance,
-                component_description=component_description,
+                component_settings=component_settings,
             )
 
-            self.filtered_molecules[filter_data.component_name] = filter_data
+            self.filtered_molecules[filter_data.component] = filter_data
 
     def add_molecule(
         self,
@@ -630,7 +630,7 @@ class BasicDataset(CommonBase):
                 component_name="QCSchemaIssues",
                 component_description={
                     "component_description": "The molecule was removed as a valid QCSchema could not be made",
-                    "component_name": "QCSchemaIssues",
+                    "type": "QCSchemaIssues",
                 },
                 component_provenance=self.provenance,
             )

--- a/openff/qcsubmit/datasets/entries.py
+++ b/openff/qcsubmit/datasets/entries.py
@@ -237,13 +237,13 @@ class FilterEntry(DatasetConfig):
     removed by it.
     """
 
-    component_name: str = Field(
+    component: str = Field(
         ...,
         description="The name of the component ran, this should be one of the components registered with qcsubmit.",
     )
-    component_description: Dict[str, Any] = Field(
+    component_settings: Dict[str, Any] = Field(
         ...,
-        description="A dictionary which captures information about what the component does including why a molecule might fail the step and the run time settings of any configurable attributes.",
+        description="The run time settings of the component used to filter the molecules.",
     )
     component_provenance: Dict[str, str] = Field(
         ...,

--- a/openff/qcsubmit/datasets/entries.py
+++ b/openff/qcsubmit/datasets/entries.py
@@ -263,3 +263,11 @@ class FilterEntry(DatasetConfig):
             kwargs["molecules"] = molecules
 
         super().__init__(**kwargs)
+
+    def add_molecule(self, molecule: off.Molecule) -> None:
+        """
+        Add a molecule to this filter.
+        """
+        self.molecules.append(
+            molecule.to_smiles(isomeric=True, explicit_hydrogens=True)
+        )

--- a/openff/qcsubmit/factories.py
+++ b/openff/qcsubmit/factories.py
@@ -1,10 +1,10 @@
+import abc
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import tqdm
 from openff.toolkit import topology as off
 from pydantic import Field, validator
-from qcportal import FractalClient
 from qcportal.models.common_models import DriverEnum
 from typing_extensions import Literal
 
@@ -28,41 +28,49 @@ from openff.qcsubmit.procedures import GeometricProcedure
 from openff.qcsubmit.serializers import deserialize, serialize
 from openff.qcsubmit.workflow_components import CustomWorkflowComponent, get_component
 
+C = TypeVar("C", bound=CustomWorkflowComponent)
+T = TypeVar("T", bound=BasicDataset)
 
-class BasicDatasetFactory(CommonBase):
+
+class BaseDatasetFactory(CommonBase, abc.ABC):
     """
-    Basic dataset generator factory used to build work flows using workflow components before executing them to generate
-    a dataset.
-
-    The basic dataset is ideal for large collections of single point calculations using any of the energy, gradient or
-    hessian drivers.
+    The Base factory which all other dataset factories should inherit from.
     """
 
-    factory_type: Literal["BasicDatasetFactory"] = Field(
-        "BasicDatasetFactory",
+    factory_type: Literal["BaseDatasetFactory"] = Field(
+        "BaseDatasetFactory",
         description="The type of dataset factory which corresponds to the dataset made.",
     )
-    workflow: Dict[str, CustomWorkflowComponent] = Field(
-        {},
+    workflow: List[C] = Field(
+        [],
         description="The set of workflow components and their settings which will be executed in order on the input molecules to make the dataset.",
     )
-    _dataset_type: BasicDataset = BasicDataset
 
-    def _get_molecular_complex_info(self) -> Dict[str, Any]:
-        """
-        Make a molecular complex dummy filter
+    @classmethod
+    @abc.abstractmethod
+    def _dataset_type(cls) -> Type[BasicDataset]:
+        """Get the type of dataset made by this factory."""
+        ...
 
-        Returns:
-            A dictionary to collect any molecules which are molecular complexes and should be removed.
+    def _molecular_complex_filter(self, dataset: T, molecule: off.Molecule) -> None:
         """
-        return {
-            "component_name": "MolecularComplexRemoval",
-            "component_description": {
-                "component_description": "Remove any molecules which are complexes.",
-            },
-            "component_provenance": self.provenance(),
-            "molecules": [],
-        }
+        Make a molecular complex dummy filter and filter a molecule.
+        """
+        try:
+            dataset.filtered_molecules["MolecularComplexRemoval"].add_molecule(
+                molecule=molecule
+            )
+        except KeyError:
+            dataset.filter_molecules(
+                molecules=[
+                    molecule,
+                ],
+                component_name="MolecularComplexRemoval",
+                component_description={
+                    "component_description": "Remove any molecules which are complexes."
+                },
+                component_provenance=self.provenance(),
+            )
 
     def provenance(self) -> Dict[str, str]:
         """
@@ -96,13 +104,13 @@ class BasicDatasetFactory(CommonBase):
         """
         Reset the workflow to by empty.
         """
-        self.workflow = {}
+        self.workflow = []
 
     def add_workflow_component(
         self,
         components: Union[
-            List[CustomWorkflowComponent],
-            CustomWorkflowComponent,
+            List[C],
+            C,
         ],
     ) -> None:
         """
@@ -125,22 +133,12 @@ class BasicDatasetFactory(CommonBase):
             if issubclass(type(component), CustomWorkflowComponent):
                 try:
                     component.is_available()
+                    self.workflow.append(component)
                 except ModuleNotFoundError as e:
                     raise ComponentRequirementError(
                         f"The component {component.component_name} could not be added to "
                         f"the workflow due to missing requirements"
                     ) from e
-                if component.component_name not in self.workflow.keys():
-                    self.workflow[component.component_name] = component
-                else:
-                    # we should increment the name and add it to the workflow
-                    if "@" in component.component_name:
-                        name, number = component.component_name.split("@")
-                    else:
-                        name, number = component.component_name, 0
-                    # set the new name
-                    component.component_name = f"{name}@{int(number) + 1}"
-                    self.workflow[component.component_name] = component
 
             else:
                 raise InvalidWorkflowComponentError(
@@ -148,32 +146,36 @@ class BasicDatasetFactory(CommonBase):
                     f"class of CustomWorkflowComponent."
                 )
 
-    def get_workflow_component(self, component_name: str) -> CustomWorkflowComponent:
+    def get_workflow_component(self, component_name: str) -> List[C]:
         """
-        Find the workflow component by its component_name attribute.
+        Find any workflow components with this component name.
 
         Parameters:
             component_name: The name of the component to be gathered from the workflow.
 
         Returns:
-            The instance of the requested component from the workflow.
+            A list of instances of the requested component from the workflow.
 
         Raises:
             MissingWorkflowComponentError: If the component could not be found by its component name in the workflow.
         """
 
-        component = self.workflow.get(component_name, None)
-        if component is None:
+        components = [
+            component
+            for component in self.workflow
+            if component.component_name.lower() == component_name.lower()
+        ]
+        if not components:
             raise MissingWorkflowComponentError(
                 f"The requested component {component_name} "
                 f"was not registered into the workflow."
             )
 
-        return component
+        return components
 
     def remove_workflow_component(self, component_name: str) -> None:
         """
-        Find and remove the component via its component_name attribute.
+        Find and remove any components via its component_name attribute.
 
         Parameters:
             component_name: The name of the component to be gathered from the workflow.
@@ -182,10 +184,11 @@ class BasicDatasetFactory(CommonBase):
             MissingWorkflowComponentError: If the component could not be found by its component name in the workflow.
         """
 
-        try:
-            del self.workflow[component_name]
-
-        except KeyError:
+        components = self.get_workflow_component(component_name=component_name)
+        if components:
+            for component in components:
+                self.workflow.remove(component)
+        else:
             raise MissingWorkflowComponentError(
                 f"The requested component {component_name} "
                 f"could not be removed as it was not registered."
@@ -214,13 +217,9 @@ class BasicDatasetFactory(CommonBase):
             workflow = workflow.get("workflow", workflow)
 
         # load in the workflow
-        for key, value in workflow.items():
+        for value in workflow.values():
             # check if this is not the first instance of the component
-            if "@" in key:
-                name = key.split("@")[0]
-            else:
-                name = key
-            component = get_component(name)
+            component = get_component(value["component_name"])
             self.add_workflow_component(component.parse_obj(value))
 
     def export_workflow(self, file_name: str) -> None:
@@ -287,72 +286,6 @@ class BasicDatasetFactory(CommonBase):
         # now we want to add the workflow back in
         self.import_workflow(workflow=workflow, clear_existing=clear_workflow)
 
-    def _get_collection(
-        self, dataset_type: str, dataset_name: str, client: Union[str, FractalClient]
-    ) -> "Collection":
-        """
-        Try and get the requested collection from the archive.
-        """
-
-        try:
-            collection = client.get_collection(dataset_type, dataset_name)
-            return collection
-        except KeyError:
-            raise KeyError(
-                f"The collection: {dataset_name} could not be found, you can only add compute to existing"
-                f" collections."
-            )
-
-    def add_compute(
-        self,
-        dataset_name: str,
-        client: Union[str, FractalClient],
-        await_result: bool = False,
-    ) -> None:
-        """
-        A method that can add compute to an existing collection, this involves registering the QM settings and keywords
-        and running the compute.
-
-        Parameters:
-            dataset_name: The name of the collection in the qcarchive instance that the compute should be added to.
-            await_result: If the function should block until the calculations have finished.
-            client: The name of the file containing the client information or the client instance.
-        """
-
-        import qcportal as ptl
-
-        target_client = self._activate_client(client)
-
-        collection = self._get_collection(
-            dataset_type="Dataset", dataset_name=dataset_name, client=target_client
-        )
-
-        kw = ptl.models.KeywordSet(
-            values=self.dict(include={"maxiter", "scf_properties"})
-        )
-        try:
-            # try add the keywords, if we get an error they have already been added.
-            collection.add_keywords(
-                alias=self.spec_name, program=self.program, keyword=kw, default=False
-            )
-            # save the keywords
-            collection.save()
-        except (KeyError, AttributeError):
-            pass
-
-        # submit the calculations
-        response = collection.compute(
-            method=self.method,
-            basis=self.basis,
-            keywords=self.spec_name,
-            program=self.program,
-            tag=self.compute_tag,
-            priority=self.priority,
-        )
-        collection.save()
-
-        return response
-
     def _create_initial_component_result(
         self, molecules: Union[str, off.Molecule, List[off.Molecule]]
     ) -> ComponentResult:
@@ -404,6 +337,13 @@ class BasicDatasetFactory(CommonBase):
 
         return workflow_molecules
 
+    @abc.abstractmethod
+    def _process_molecule(self, dataset: T, molecule: off.Molecule) -> None:
+        """
+        Process the molecules returned from running the workflow into a new dataset.
+        """
+        ...
+
     def create_dataset(
         self,
         dataset_name: str,
@@ -413,7 +353,7 @@ class BasicDatasetFactory(CommonBase):
         metadata: Optional[Metadata] = None,
         processors: Optional[int] = None,
         verbose: bool = True,
-    ) -> BasicDataset:
+    ) -> T:
         """
         Process the input molecules through the given workflow then create and populate the dataset class which acts as
         a local representation for the collection in qcarchive and has the ability to submit its self to a local or
@@ -457,7 +397,6 @@ class BasicDatasetFactory(CommonBase):
         # TODO set up a logging system to report the components
 
         #  create an initial component result
-
         workflow_molecules = self._create_initial_component_result(molecules=molecules)
 
         # create the dataset
@@ -471,11 +410,11 @@ class BasicDatasetFactory(CommonBase):
         object_meta["dataset_tagline"] = tagline
         if metadata is not None:
             object_meta["metadata"] = metadata.dict()
-        dataset = self._dataset_type.parse_obj(object_meta)
+        dataset = self._dataset_type().parse_obj(object_meta)
 
         # if the workflow has components run it
         if self.workflow:
-            for component in self.workflow.values():
+            for component in self.workflow:
                 workflow_molecules = component.apply(
                     molecules=workflow_molecules.molecules,
                     processors=processors,
@@ -489,9 +428,6 @@ class BasicDatasetFactory(CommonBase):
                     component_provenance=workflow_molecules.component_provenance,
                 )
 
-        # get a molecular complex filter
-        molecular_complex = self._get_molecular_complex_info()
-
         # now add the molecules to the correct attributes
         for molecule in tqdm.tqdm(
             workflow_molecules.molecules,
@@ -500,31 +436,7 @@ class BasicDatasetFactory(CommonBase):
             desc="{:30s}".format("Preparation"),
             disable=not verbose,
         ):
-            # order the molecule
-            order_mol = molecule.canonical_order_atoms()
-            attributes = self.create_cmiles_metadata(molecule=order_mol)
-            attributes.provenance = self.provenance()
-
-            # always put the cmiles in the extras from what we have just calculated to ensure correct order
-            extras = molecule.properties.get("extras", {})
-
-            keywords = molecule.properties.get("keywords", None)
-
-            # now submit the molecule
-            try:
-                dataset.add_molecule(
-                    index=self.create_index(molecule=order_mol),
-                    molecule=order_mol,
-                    attributes=attributes,
-                    extras=extras if bool(extras) else None,
-                    keywords=keywords,
-                )
-            except MolecularComplexError:
-                molecular_complex["molecules"].append(molecule)
-
-        # add the complexes if there are any
-        if molecular_complex["molecules"]:
-            dataset.filter_molecules(**molecular_complex)
+            self._process_molecule(dataset=dataset, molecule=molecule)
 
         return dataset
 
@@ -575,6 +487,45 @@ class BasicDatasetFactory(CommonBase):
         return index
 
 
+class BasicDatasetFactory(BaseDatasetFactory):
+    """
+    Basic dataset generator factory used to build work flows using workflow components before executing them to generate
+    a dataset.
+
+    The basic dataset is ideal for large collections of single point calculations using any of the energy, gradient or
+    hessian drivers.
+    """
+
+    factory_type: Literal["BasicDatasetFactory"] = "BasicDatasetFactory"
+
+    @classmethod
+    def _dataset_type(cls) -> Type[BasicDataset]:
+        return BasicDataset
+
+    def _process_molecule(self, dataset: T, molecule: off.Molecule) -> None:
+        # order the molecule
+        order_mol = molecule.canonical_order_atoms()
+        attributes = self.create_cmiles_metadata(molecule=order_mol)
+        attributes.provenance = self.provenance()
+
+        # always put the cmiles in the extras from what we have just calculated to ensure correct order
+        extras = molecule.properties.get("extras", {})
+
+        keywords = molecule.properties.get("keywords", None)
+
+        # now submit the molecule
+        try:
+            dataset.add_molecule(
+                index=self.create_index(molecule=order_mol),
+                molecule=order_mol,
+                attributes=attributes,
+                extras=extras if bool(extras) else None,
+                keywords=keywords,
+            )
+        except MolecularComplexError:
+            self._molecular_complex_filter(dataset=dataset, molecule=molecule)
+
+
 class OptimizationDatasetFactory(BasicDatasetFactory):
     """
     This factory produces OptimisationDatasets which include settings associated with geometric which is used to run the
@@ -586,14 +537,17 @@ class OptimizationDatasetFactory(BasicDatasetFactory):
         description="The type of dataset factory which corresponds to the dataset made.",
     )
     # set the driver to be gradient this should not be changed when running
-    driver = DriverEnum.gradient
-    _dataset_type = OptimizationDataset
+    driver: DriverEnum = DriverEnum.gradient
 
     # use the default geometric settings during optimisation
     optimization_program: GeometricProcedure = Field(
         GeometricProcedure(),
         description="The optimization program and settings that should be used.",
     )
+
+    @classmethod
+    def _dataset_type(cls) -> Type[OptimizationDataset]:
+        return OptimizationDataset
 
     @validator("driver")
     def _check_driver(cls, driver):
@@ -605,64 +559,6 @@ class OptimizationDatasetFactory(BasicDatasetFactory):
                 f"drivers: {available_drivers}"
             )
         return driver
-
-    def add_compute(
-        self,
-        dataset_name: str,
-        client: Union[str, FractalClient],
-        await_result: bool = False,
-    ) -> None:
-        """
-        A method that can add compute to an existing collection, this involves registering the QM settings and keywords
-        and running the compute.
-
-        Parameters:
-            dataset_name: The name of the collection in the qcarchive instance that the compute should be added to.
-            await_result: If the function should block until the calculations have finished.
-            client: The name of the file containing the client information or the client instance.
-        """
-
-        import qcportal as ptl
-
-        target_client = self._activate_client(client)
-
-        # try and get the collection.
-        collection = self._get_collection(
-            dataset_type=self._dataset_type.__name__,
-            dataset_name=dataset_name,
-            client=target_client,
-        )
-
-        # create the keywords
-        kw = ptl.models.KeywordSet(
-            values=self.dict(include={"maxiter", "scf_properties"})
-        )
-
-        kw_id = target_client.add_keywords([kw])[0]
-        # create the spec
-        opt_spec = self.optimization_program.get_optimzation_spec()
-        qc_spec = ptl.models.common_models.QCSpecification(
-            driver=self.driver,
-            method=self.method,
-            basis=self.basis,
-            keywords=kw_id,
-            program=self.program,
-        )
-
-        # now add the compute tasks
-        collection.add_specification(
-            name=self.spec_name,
-            optimization_spec=opt_spec,
-            qc_spec=qc_spec,
-            description=self.spec_description,
-            overwrite=False,
-        )
-
-        response = collection.compute(
-            specification=self.spec_name, tag=self.compute_tag, priority=self.priority
-        )
-
-        return response
 
 
 class TorsiondriveDatasetFactory(OptimizationDatasetFactory):
@@ -691,186 +587,118 @@ class TorsiondriveDatasetFactory(OptimizationDatasetFactory):
         None,
         description="The energy lower threshold to trigger new optimizations in the torsiondrive.",
     )
-    _dataset_type = TorsiondriveDataset
 
     # set the default settings for a torsiondrive calculation.
     optimization_program = GeometricProcedure.parse_obj(
         {"enforce": 0.1, "reset": True, "qccnv": True, "epsilon": 0.0}
     )
 
-    def create_dataset(
-        self,
-        dataset_name: str,
-        molecules: Union[str, List[off.Molecule], off.Molecule],
-        description: str,
-        tagline: str,
-        metadata: Optional[Metadata] = None,
-        processors: Optional[int] = None,
-        verbose: bool = True,
-    ) -> TorsiondriveDataset:
+    @classmethod
+    def _dataset_type(cls) -> Type[TorsiondriveDataset]:
+        return TorsiondriveDataset
+
+    def _linear_torsion_filter(self, dataset: T, molecule: off.Molecule) -> None:
         """
-        Process the input molecules through the given workflow then create and populate the torsiondrive
-        dataset class which acts as a local representation for the collection in qcarchive and has the ability to
-        submit its self to a local or public instance.
-
-        Note:
-            The torsiondrive dataset allows for multiple starting geometries.
-            If fragmentation is used each molecule in the dataset will have the torsion indexes already set else indexes
-            are generated for each rotatable torsion in the molecule.
-
-        Important:
-            Any molecules with linear torsions identified for torsion driving will be removed and failed from the
-            workflow.
-
-        Parameters:
-             dataset_name: The name that will be given to the collection on submission to an archive instance.
-             molecules: The list of molecules which should be processed by the workflow and added to the dataset, this
-                can also be a file name which is to be unpacked by the openforcefield toolkit.
-            description: A short string describing the dataset.
-            tagline: A short string overview of the collection displayed on the QCArchive.
-            metadata: Any metadata which should be associated with this dataset this can be changed from the default
-                after making the dataset.
-            processors: The number of processors avilable to the workflow, note None will use all avilable processors.
-            verbose: If True a progress bar for each workflow component will be shown.
-
-        Returns:
-            A [DataSet][qcsubmit.datasets.TorsiondriveDataset] instance populated with the molecules that have passed
-            through the workflow.
+        Mock a linear torsion filtering component and filter the molecule.
         """
+        try:
+            dataset.filtered_molecules["LinearTorsionRemoval"].add_molecule(
+                molecule=molecule
+            )
+        except KeyError:
+            dataset.filter_molecules(
+                molecules=[
+                    molecule,
+                ],
+                component_name="LinearTorsionRemoval",
+                component_description={
+                    "component_description": "Remove any molecules with a linear torsions selected to drive."
+                },
+                component_provenance=self.provenance(),
+            )
 
-        # create the initial component result
-        workflow_molecules = self._create_initial_component_result(molecules=molecules)
+    def _unconnected_torsion_filter(self, dataset: T, molecule: off.Molecule) -> None:
+        """Mock a unconnected torsion filtering component and filter the molecule."""
 
-        # catch any linear torsions here
-        linear_torsions = {
-            "component_name": "LinearTorsionRemoval",
-            "component_description": {
-                "component_description": "Remove any molecules with a linear torsions selected to drive.",
-            },
-            "component_provenance": self.provenance(),
-            "molecules": [],
-        }
+        try:
+            dataset.filtered_molecules["UnconnectedTorsionRemoval"].add_molecule(
+                molecule=molecule
+            )
+        except KeyError:
+            dataset.filter_molecules(
+                molecules=[
+                    molecule,
+                ],
+                component_name="UnconnectedTorsionRemoval",
+                component_description={
+                    "component_description": "Remove any molecules with unconnected torsion indices highlighted to drive."
+                },
+                component_provenance=self.provenance(),
+            )
 
-        unconnected_torsions = {
-            "component_name": "UnconnectedTorsionRemoval",
-            "component_description": {
-                "component_description": "Remove any molecules with unconnected torsion indices highlighted to drive.",
-            },
-            "component_provenance": self.provenance(),
-            "molecules": [],
-        }
+    def _process_molecule(self, dataset: T, molecule: off.Molecule) -> None:
+        # check for extras and keywords
+        extras = molecule.properties.get("extras", {})
+        keywords = molecule.properties.get("keywords", {})
 
-        molecular_complex = self._get_molecular_complex_info()
+        # make the general attributes
+        attributes = self.create_cmiles_metadata(molecule=molecule)
 
-        # first we need to instance the dataset and assign the metadata
-        object_meta = self.dict(exclude={"workflow"})
+        # now check for the dihedrals
+        if "dihedrals" in molecule.properties:
+            # first do 1-D torsions
+            for dihedral in molecule.properties["dihedrals"].get_dihedrals:
+                # create the index
+                molecule.properties["atom_map"] = dihedral.get_atom_map
+                index = self.create_index(molecule=molecule)
+                del molecule.properties["atom_map"]
+                # get the dihedrals to scan
+                dihedrals = dihedral.get_dihedrals
 
-        # the only data missing is the collection name so add it here.
-        object_meta["dataset_name"] = dataset_name
-        object_meta["description"] = description
-        object_meta["provenance"] = self.provenance()
-        object_meta["dataset_tagline"] = tagline
-        if metadata is not None:
-            object_meta["metadata"] = metadata.dict()
-        dataset = self._dataset_type(**object_meta)
-
-        # if the workflow has components run it
-        if self.workflow:
-            for component_name, component in self.workflow.items():
-                workflow_molecules = component.apply(
-                    molecules=workflow_molecules.molecules,
-                    processors=processors,
-                    verbose=verbose,
-                )
-
-                dataset.filter_molecules(
-                    molecules=workflow_molecules.filtered,
-                    component_name=workflow_molecules.component_name,
-                    component_description=workflow_molecules.component_description,
-                    component_provenance=workflow_molecules.component_provenance,
-                )
-
-        # now add the molecules to the correct attributes
-        for molecule in tqdm.tqdm(
-            workflow_molecules.molecules,
-            total=len(workflow_molecules.molecules),
-            ncols=80,
-            desc="{:30s}".format("Preparation"),
-            disable=not verbose,
-        ):
-            # check for extras and keywords
-            extras = molecule.properties.get("extras", {})
-            keywords = molecule.properties.get("keywords", {})
-
-            # make the general attributes
-            attributes = self.create_cmiles_metadata(molecule=molecule)
-            # attributes = cmiles.get_molecule_ids(molecule)
-
-            # now check for the dihedrals
-            if "dihedrals" in molecule.properties:
-                # first do 1-D torsions
-                for dihedral in molecule.properties["dihedrals"].get_dihedrals:
-                    # create the index
-                    molecule.properties["atom_map"] = dihedral.get_atom_map
-                    index = self.create_index(molecule=molecule)
-                    del molecule.properties["atom_map"]
-                    # get the dihedrals to scan
-                    dihedrals = dihedral.get_dihedrals
-
-                    keywords["dihedral_ranges"] = dihedral.get_scan_range
-                    try:
-                        dataset.add_molecule(
-                            index=index,
-                            molecule=molecule,
-                            attributes=attributes,
-                            dihedrals=dihedrals,
-                            keywords=keywords,
-                            extras=extras,
-                        )
-                    except DihedralConnectionError:
-                        unconnected_torsions["molecules"].append(molecule)
-                    except LinearTorsionError:
-                        linear_torsions["molecules"].append(molecule)
-                    except MolecularComplexError:
-                        molecular_complex["molecules"].append(molecule)
-
-            else:
-                # the molecule has not had its atoms identified yet so process them here
-                # order the molecule
-                order_mol = molecule.canonical_order_atoms()
-                rotatble_bonds = order_mol.find_rotatable_bonds()
-                attributes = self.create_cmiles_metadata(molecule=order_mol)
-                for bond in rotatble_bonds:
-                    # create a torsion to hold as fixed using non-hydrogen atoms
-                    torsion_index = self._get_torsion_string(bond)
-                    order_mol.properties["atom_map"] = dict(
-                        (atom, index) for index, atom in enumerate(torsion_index)
+                keywords["dihedral_ranges"] = dihedral.get_scan_range
+                try:
+                    dataset.add_molecule(
+                        index=index,
+                        molecule=molecule,
+                        attributes=attributes,
+                        dihedrals=dihedrals,
+                        keywords=keywords,
+                        extras=extras,
                     )
-                    try:
-                        dataset.add_molecule(
-                            index=self.create_index(molecule=order_mol),
-                            molecule=order_mol,
-                            attributes=attributes,
-                            dihedrals=[torsion_index],
-                            extras=extras,
-                            keywords=keywords,
-                        )
-                    except DihedralConnectionError:
-                        unconnected_torsions["molecules"].append(molecule)
-                    except LinearTorsionError:
-                        linear_torsions["molecules"].append(molecule)
-                    except MolecularComplexError:
-                        molecular_complex["molecules"].append(molecule)
+                except DihedralConnectionError:
+                    self._unconnected_torsion_filter(dataset=dataset, molecule=molecule)
+                except LinearTorsionError:
+                    self._linear_torsion_filter(dataset=dataset, molecule=molecule)
+                except MolecularComplexError:
+                    self._molecular_complex_filter(dataset=dataset, molecule=molecule)
 
-        # now we need to filter the linear molecules
-        dataset.filter_molecules(**linear_torsions)
-        # and we need to filter any molecules with unconnected torsions
-        dataset.filter_molecules(**unconnected_torsions)
-        # add molecular complex errors
-        if molecular_complex["molecules"]:
-            dataset.filter_molecules(**molecular_complex)
-
-        return dataset
+        else:
+            # the molecule has not had its atoms identified yet so process them here
+            # order the molecule
+            order_mol = molecule.canonical_order_atoms()
+            rotatble_bonds = order_mol.find_rotatable_bonds()
+            attributes = self.create_cmiles_metadata(molecule=order_mol)
+            for bond in rotatble_bonds:
+                # create a torsion to hold as fixed using non-hydrogen atoms
+                torsion_index = self._get_torsion_string(bond)
+                order_mol.properties["atom_map"] = dict(
+                    (atom, index) for index, atom in enumerate(torsion_index)
+                )
+                try:
+                    dataset.add_molecule(
+                        index=self.create_index(molecule=order_mol),
+                        molecule=order_mol,
+                        attributes=attributes,
+                        dihedrals=[torsion_index],
+                        extras=extras,
+                        keywords=keywords,
+                    )
+                except DihedralConnectionError:
+                    self._unconnected_torsion_filter(dataset=dataset, molecule=molecule)
+                except LinearTorsionError:
+                    self._linear_torsion_filter(dataset=dataset, molecule=molecule)
+                except MolecularComplexError:
+                    self._molecular_complex_filter(dataset=dataset, molecule=molecule)
 
     def _get_torsion_string(self, bond: off.Bond) -> Tuple[int, int, int, int]:
         """

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -1132,7 +1132,7 @@ def test_componentresult_filter_molecules():
     result = ComponentResult(
         component_name="Test filtering",
         component_description={
-            "component_name": "TestFiltering",
+            "type": "TestFiltering",
             "component_description": "TestFiltering",
             "component_fail_message": "TestFiltering",
         },
@@ -1163,13 +1163,13 @@ def test_dataset_add_filter_molecules():
     methane = Molecule.from_smiles("C")
     ethanol = Molecule.from_smiles("CC")
     dataset.filter_molecules(molecules=methane,
-                             component_name="test",
-                             component_description={},
+                             component="test",
+                             component_settings={},
                              component_provenance={})
     # now we want to add this extra molecule to this group
     dataset.filter_molecules(molecules=ethanol,
-                             component_name="test",
-                             component_description={},
+                             component="test",
+                             component_settings={},
                              component_provenance={})
     filtered = dataset.filtered_molecules["test"]
     assert len(filtered.molecules) == 2
@@ -1575,8 +1575,8 @@ def test_dataset_export_dict(dataset_type):
     # add one failure
     fail = Molecule.from_smiles("C")
     dataset.filter_molecules(molecules=[fail, ],
-                             component_name="TestFailure",
-                             component_description={"name": "TestFailure"},
+                             component="TestFailure",
+                             component_settings={},
                              component_provenance={"test": "v1.0"})
 
     dataset2 = dataset_type(**dataset.dict())
@@ -1609,8 +1609,8 @@ def test_dataset_export_json(dataset_type):
     # add one failure
     fail = Molecule.from_smiles("C")
     dataset.filter_molecules(molecules=[fail, ],
-                             component_name="TestFailure",
-                             component_description={"name": "TestFailure"},
+                             component="TestFailure",
+                             component_settings={},
                              component_provenance={"test": "v1.0"})
 
     # try parse the json string to build the dataset
@@ -1648,8 +1648,8 @@ def test_dataset_roundtrip_compression(dataset_type, compression):
     # add one failure
     fail = Molecule.from_smiles("C")
     dataset.filter_molecules(molecules=[fail, ],
-                             component_name="TestFailure",
-                             component_description={"name": "TestFailure"},
+                             component="TestFailure",
+                             component_settings={},
                              component_provenance={"test": "v1.0"})
 
     with temp_directory():
@@ -1865,12 +1865,10 @@ def test_basicdataset_filtering():
     dataset = BasicDataset()
     molecules = duplicated_molecules(include_conformers=False, duplicates=1)
     # create a filtered result
-    component_description = {"component_name": "TestFilter",
-                             "component_description": "Test component for filtering molecules"}
     component_provenance = {"test_provenance": "version_1"}
     dataset.filter_molecules(molecules=molecules,
-                             component_name="TestFilter",
-                             component_description=component_description,
+                             component="TestFilter",
+                             component_settings={},
                              component_provenance=component_provenance)
 
     assert len(molecules) == dataset.n_filtered
@@ -1879,7 +1877,7 @@ def test_basicdataset_filtering():
     components = dataset.components
     assert len(components) == 1
     component = components[0]
-    assert "TestFilter" == component["component_name"]
+    assert "TestFilter" == component["component"]
     assert "version_1" == component["component_provenance"]["test_provenance"]
 
     # now loop through the molecules to make sure they match

--- a/openff/qcsubmit/tests/test_factories.py
+++ b/openff/qcsubmit/tests/test_factories.py
@@ -68,30 +68,30 @@ def test_adding_workflow_components(factory_type):
 
     # element filter
     efilter = workflow_components.ElementFilter()
-    factory.add_workflow_component(efilter)
+    factory.add_workflow_components(efilter)
 
     assert len(factory.workflow) == 1
 
     # conformer generator
     conformer_gen = workflow_components.StandardConformerGenerator()
     conformer_gen.max_conformers = 200
-    factory.add_workflow_component(conformer_gen)
+    factory.add_workflow_components(conformer_gen)
 
     assert len(factory.workflow) == 2
 
     # add element filter again and make sure the component name has been incremented
-    factory.add_workflow_component(efilter)
+    factory.add_workflow_components(efilter)
     assert len(factory.workflow) == 3
     assert efilter in factory.workflow
 
     # try to add a non component
     with pytest.raises(InvalidWorkflowComponentError):
-        factory.add_workflow_component(3)
+        factory.add_workflow_components(3)
 
     with pytest.raises(ValidationError):
         factory.workflow = {"first component": 3}
 
-    factory.workflow = [conformer_gen, ]
+    factory.workflow = [conformer_gen]
 
     assert len(factory.workflow) == 1
 
@@ -101,7 +101,7 @@ def test_adding_workflow_components(factory_type):
     pytest.param(OptimizationDatasetFactory, id="OptimizationDatasetFactory"),
     pytest.param(TorsiondriveDatasetFactory, id="TorsiondriveDatasetFactory")
 ])
-def test_adding_multipule_workflow_components(factory_type):
+def test_adding_multiple_workflow_components(factory_type):
     """
     Test adding a list of workflow components.
     """
@@ -114,7 +114,7 @@ def test_adding_multipule_workflow_components(factory_type):
 
     components = [efilter, weight, conformer]
 
-    factory.add_workflow_component(components)
+    factory.add_workflow_components(*components)
 
     assert len(factory.workflow) == 3
     for component in components:
@@ -126,7 +126,7 @@ def test_adding_multipule_workflow_components(factory_type):
     pytest.param(OptimizationDatasetFactory, id="OptimizationDatasetFactory"),
     pytest.param(TorsiondriveDatasetFactory, id="TorsiondriveDatasetFactory")
 ])
-def test_remove_workflow_componet(factory_type):
+def test_remove_workflow_component(factory_type):
     """
     Test removing a workflow component through the API.
     """
@@ -138,12 +138,12 @@ def test_remove_workflow_componet(factory_type):
 
     components = [efilter, weight, conformer]
 
-    factory.add_workflow_component(components)
+    factory.add_workflow_components(*components)
 
     assert len(factory.workflow) == 3
 
     for component in components:
-        factory.remove_workflow_component(component.component_name)
+        factory.remove_workflow_component(component.type)
 
     assert factory.workflow == []
 
@@ -166,10 +166,10 @@ def test_get_wrokflow_component(factory_type):
 
     components = [efilter, weight, conformer]
 
-    factory.add_workflow_component(components)
+    factory.add_workflow_components(*components)
 
     for component in components:
-        assert factory.get_workflow_component(component.component_name) == [component, ]
+        assert factory.get_workflow_components(component.type) == [component]
 
 
 @pytest.mark.parametrize("factory_type", [
@@ -190,17 +190,37 @@ def test_clear_workflow(factory_type):
 
     components = [efilter, weight, conformer]
 
-    factory.add_workflow_component(components)
+    factory.add_workflow_components(*components)
 
     factory.clear_workflow()
 
     assert factory.workflow == []
 
-    factory.add_workflow_component(components)
+    factory.add_workflow_components(*components)
 
     factory.workflow = []
 
     assert factory.workflow == []
+
+
+@pytest.mark.parametrize("file_type", [pytest.param("json", id="json"), pytest.param("yaml", id="yaml")])
+def test_factory_round_trip(file_type, tmpdir):
+    """
+    Test round tripping a factory to file with a workflow.
+    """
+    with tmpdir.as_cwd():
+        factory = BasicDatasetFactory(driver="energy", maxiter=1)
+        efilter = workflow_components.ElementFilter()
+        weight = workflow_components.MolecularWeightFilter()
+        conformer = workflow_components.StandardConformerGenerator()
+        factory.add_workflow_components(efilter, weight, conformer)
+        file_name = "test." + file_type
+        factory.export(file_name)
+
+        factory2 = BasicDatasetFactory.from_file(file_name)
+        assert factory2.driver == factory.driver
+        assert factory2.maxiter == factory.maxiter
+        assert factory2.workflow == factory.workflow
 
 
 @pytest.mark.parametrize("file_type", [pytest.param("json", id="json"), pytest.param("yaml", id="yaml")])
@@ -251,7 +271,7 @@ def test_exporting_settings_workflow(file_type, factory_type):
 
         conformer_gen = workflow_components.StandardConformerGenerator()
         conformer_gen.max_conformers = 100
-        factory.add_workflow_component(conformer_gen)
+        factory.add_workflow_components(conformer_gen)
 
         file_name = "test." + file_type
 
@@ -259,7 +279,7 @@ def test_exporting_settings_workflow(file_type, factory_type):
 
         with open(file_name) as f:
             data = f.read()
-            assert conformer_gen.component_name in data
+            assert conformer_gen.type in data
             assert str(conformer_gen.max_conformers) in data
 
 
@@ -313,7 +333,7 @@ def test_importing_settings_workflow(file_type, factory_type):
         assert getattr(factory, attr) == value
 
     assert len(factory.workflow) == 1
-    component = factory.get_workflow_component("StandardConformerGenerator")[0]
+    component = factory.get_workflow_components("StandardConformerGenerator")[0]
     assert component.description() == "Generate conformations for the given molecules."
     assert isinstance(component, workflow_components.StandardConformerGenerator) is True
 
@@ -359,7 +379,7 @@ def test_export_workflow_only(file_type, factory_type):
         conformer_gen = workflow_components.StandardConformerGenerator()
         conformer_gen.max_conformers = 100
 
-        factory.add_workflow_component(conformer_gen)
+        factory.add_workflow_components(conformer_gen)
 
         file_name = "workflow." + file_type
         factory.export_workflow(file_name)
@@ -514,9 +534,9 @@ def test_create_dataset(factory_dataset_type):
     factory = factory_dataset_type[0]()
     element_filter = workflow_components.ElementFilter()
     element_filter.allowed_elements = [1, 6, 8, 7]
-    factory.add_workflow_component(element_filter)
+    factory.add_workflow_components(element_filter)
     conformer_generator = workflow_components.StandardConformerGenerator(max_conformers=1)
-    factory.add_workflow_component(conformer_generator)
+    factory.add_workflow_components(conformer_generator)
 
     mols = Molecule.from_file(get_data("tautomers_small.smi"), "smi", allow_undefined_stereo=True)
 
@@ -540,4 +560,4 @@ def test_create_dataset(factory_dataset_type):
     # make sure molecules we filtered and passed
     assert dataset.dataset != {}
     assert dataset.filtered != {}
-    assert element_filter.component_name in dataset.filtered_molecules
+    assert element_filter.type in dataset.filtered_molecules

--- a/openff/qcsubmit/tests/test_factories.py
+++ b/openff/qcsubmit/tests/test_factories.py
@@ -82,7 +82,7 @@ def test_adding_workflow_components(factory_type):
     # add element filter again and make sure the component name has been incremented
     factory.add_workflow_component(efilter)
     assert len(factory.workflow) == 3
-    assert efilter.component_name in factory.workflow
+    assert efilter in factory.workflow
 
     # try to add a non component
     with pytest.raises(InvalidWorkflowComponentError):
@@ -91,7 +91,7 @@ def test_adding_workflow_components(factory_type):
     with pytest.raises(ValidationError):
         factory.workflow = {"first component": 3}
 
-    factory.workflow = {"test_conformer": conformer_gen}
+    factory.workflow = [conformer_gen, ]
 
     assert len(factory.workflow) == 1
 
@@ -118,7 +118,7 @@ def test_adding_multipule_workflow_components(factory_type):
 
     assert len(factory.workflow) == 3
     for component in components:
-        assert component.component_name in factory.workflow
+        assert component in factory.workflow
 
 
 @pytest.mark.parametrize("factory_type", [
@@ -145,7 +145,7 @@ def test_remove_workflow_componet(factory_type):
     for component in components:
         factory.remove_workflow_component(component.component_name)
 
-    assert factory.workflow == {}
+    assert factory.workflow == []
 
 
 @pytest.mark.parametrize("factory_type", [
@@ -169,7 +169,7 @@ def test_get_wrokflow_component(factory_type):
     factory.add_workflow_component(components)
 
     for component in components:
-        assert factory.get_workflow_component(component.component_name) == component
+        assert factory.get_workflow_component(component.component_name) == [component, ]
 
 
 @pytest.mark.parametrize("factory_type", [
@@ -194,13 +194,13 @@ def test_clear_workflow(factory_type):
 
     factory.clear_workflow()
 
-    assert factory.workflow == {}
+    assert factory.workflow == []
 
     factory.add_workflow_component(components)
 
-    factory.workflow = {}
+    factory.workflow = []
 
-    assert factory.workflow == {}
+    assert factory.workflow == []
 
 
 @pytest.mark.parametrize("file_type", [pytest.param("json", id="json"), pytest.param("yaml", id="yaml")])
@@ -313,9 +313,8 @@ def test_importing_settings_workflow(file_type, factory_type):
         assert getattr(factory, attr) == value
 
     assert len(factory.workflow) == 1
-    assert "StandardConformerGenerator" in factory.workflow
-    component = factory.get_workflow_component("StandardConformerGenerator")
-    assert component.component_description == "loaded component"
+    component = factory.get_workflow_component("StandardConformerGenerator")[0]
+    assert component.description() == "Generate conformations for the given molecules."
     assert isinstance(component, workflow_components.StandardConformerGenerator) is True
 
 

--- a/openff/qcsubmit/tests/test_submissions.py
+++ b/openff/qcsubmit/tests/test_submissions.py
@@ -842,7 +842,7 @@ def test_ignore_errors_all_datasets(fractal_compute_server, factory_type, capsys
     factory.clear_qcspecs()
     # add only mm specs
     factory.add_qc_spec(method="openff-1.0.0", basis="smirnoff", program="openmm", spec_name="parsley", spec_description="standard parsley spec")
-    dataset = factory.create_dataset(dataset_name=f"Test ignore_error for {factory.factory_type}",
+    dataset = factory.create_dataset(dataset_name=f"Test ignore_error for {factory.type}",
                                      molecules=molecule,
                                      description="Test ignore errors dataset",
                                      tagline="Testing ignore errors datasets",
@@ -880,7 +880,7 @@ def test_index_not_changed(fractal_compute_server, factory_type):
     molecule = Molecule.from_smiles("C")
     # make sure we only have one conformer
     molecule.generate_conformers(n_conformers=1)
-    dataset = factory.create_dataset(dataset_name=f"Test index change for {factory.factory_type}",
+    dataset = factory.create_dataset(dataset_name=f"Test index change for {factory.type}",
                                      molecules=molecule,
                                      description="Test index change dataset",
                                      tagline="Testing index changes datasets",
@@ -920,7 +920,7 @@ def test_adding_dataset_entry_fail(fractal_compute_server, factory_type, capsys)
     factory.clear_qcspecs()
     # add only mm specs
     factory.add_qc_spec(method="openff-1.0.0", basis="smirnoff", program="openmm", spec_name="parsley", spec_description="standard parsley spec")
-    dataset = factory.create_dataset(dataset_name=f"Test index clash for {factory.factory_type}",
+    dataset = factory.create_dataset(dataset_name=f"Test index clash for {factory.type}",
                                      molecules=molecule,
                                      description="Test ignore errors dataset",
                                      tagline="Testing ignore errors datasets",
@@ -957,7 +957,7 @@ def test_expanding_compute(fractal_compute_server, factory_type):
     # add only mm specs
     factory.add_qc_spec(method="openff-1.0.0", basis="smirnoff", program="openmm", spec_name="default",
                         spec_description="standard parsley spec")
-    dataset = factory.create_dataset(dataset_name=f"Test compute expand {factory.factory_type}",
+    dataset = factory.create_dataset(dataset_name=f"Test compute expand {factory.type}",
                                      molecules=molecule,
                                      description="Test compute expansion",
                                      tagline="Testing compute expansion",
@@ -976,7 +976,7 @@ def test_expanding_compute(fractal_compute_server, factory_type):
     # add only mm specs
     factory.add_qc_spec(method="openff-1.2.0", basis="smirnoff", program="openmm", spec_name="parsley2",
                         spec_description="standard parsley spec")
-    dataset = factory.create_dataset(dataset_name=f"Test compute expand {factory.factory_type}",
+    dataset = factory.create_dataset(dataset_name=f"Test compute expand {factory.type}",
                                      molecules=[],
                                      description="Test compute expansion",
                                      tagline="Testing compute expansion",

--- a/openff/qcsubmit/tests/test_workflow_components.py
+++ b/openff/qcsubmit/tests/test_workflow_components.py
@@ -63,7 +63,7 @@ def test_list_components():
     """
     components = list_components()
     for component in components:
-        assert component.component_name == component.__class__.__name__
+        assert component.type == component.__class__.__name__
 
 
 def test_register_component_replace():
@@ -79,7 +79,7 @@ def test_register_component_replace():
     # now register using replace with a new default
     register_component(component=gen, replace=True)
 
-    gen2 = get_component(gen.component_name)
+    gen2 = get_component(gen.type)
     assert gen2.max_conformers == gen.max_conformers
 
     # now return th list back to normal
@@ -91,7 +91,7 @@ def test_register_component_error():
     Make sure an error is raised if we try and register a component that is not a sub class of CustomWorkflowComponent.
     """
     # fake component
-    charge_filter = {"component_name": "charge_filter"}
+    charge_filter = {"type": "charge_filter"}
 
     with pytest.raises(InvalidWorkflowComponentError):
         register_component(component=charge_filter)
@@ -179,7 +179,7 @@ def test_custom_component():
     assert test.description() == "Test component"
     assert test.fail_reason() == "Test fail"
     assert {"test": "version1"} == test.provenance()
-    assert TestComponent.inifo() == {"name": "TestComponent", "description": "Test component", "fail_reason": "Test fail"}
+    assert TestComponent.info() == {"name": "TestComponent", "description": "Test component", "fail_reason": "Test fail"}
 
 
 @pytest.mark.parametrize(
@@ -401,7 +401,7 @@ def test_conformer_apply(toolkit):
 
         result = conf_gen.apply(molecule_container.molecules, processors=1)
 
-        assert result.component_name == conf_gen.component_name
+        assert result.component_name == conf_gen.type
         assert result.component_description == conf_gen.dict()
         # make sure each molecule has a conformer that passed
         for molecule in result.molecules:
@@ -426,7 +426,7 @@ def test_elementfilter_apply():
 
     result = elem_filter.apply(mols, processors=1)
 
-    assert result.component_name == elem_filter.component_name
+    assert result.component_name == elem_filter.type
     assert result.component_description == elem_filter.dict()
     # make sure there are no unwanted elements in the pass set
     for molecue in result.molecules:
@@ -867,7 +867,7 @@ def test_smarts_filter_apply_parameters():
 
     result = filter.apply(molecules, processors=1)
 
-    assert result.component_name == filter.component_name
+    assert result.component_name == filter.type
     assert result.component_description == filter.dict()
     # make sure there are no unwanted elements in the pass set
     for molecule in result.molecules:

--- a/openff/qcsubmit/workflow_components/__init__.py
+++ b/openff/qcsubmit/workflow_components/__init__.py
@@ -1,4 +1,5 @@
 from openff.qcsubmit.workflow_components.base import (
+    Components,
     deregister_component,
     get_component,
     list_components,

--- a/openff/qcsubmit/workflow_components/base.py
+++ b/openff/qcsubmit/workflow_components/base.py
@@ -34,12 +34,25 @@ __all__ = [
     "list_components",
 ]
 
-workflow_components: Dict[str, CustomWorkflowComponent] = {}
+# make a components type
+Components = Union[
+    StandardConformerGenerator,
+    RMSDCutoffConformerFilter,
+    CoverageFilter,
+    ElementFilter,
+    MolecularWeightFilter,
+    RotorFilter,
+    SmartsFilter,
+    EnumerateTautomers,
+    EnumerateProtomers,
+    EnumerateStereoisomers,
+    WBOFragmenter,
+]
+
+workflow_components: Dict[str, Components] = {}
 
 
-def register_component(
-    component: CustomWorkflowComponent, replace: bool = False
-) -> None:
+def register_component(component: Components, replace: bool = False) -> None:
     """
     Register a valid workflow component with qcsubmit.
 
@@ -53,14 +66,14 @@ def register_component(
     """
 
     if issubclass(type(component), CustomWorkflowComponent):
-        component_name = component.component_name.lower()
+        component_name = component.type.lower()
         if component_name not in workflow_components or (
             component_name in workflow_components and replace
         ):
             workflow_components[component_name] = component
         else:
             raise ComponentRegisterError(
-                f"There is already a component registered with QCSubmit with the name {component.component_name}, to replace this use the `replace=True` flag."
+                f"There is already a component registered with QCSubmit with the name {component.type}, to replace this use the `replace=True` flag."
             )
     else:
         raise InvalidWorkflowComponentError(
@@ -68,7 +81,7 @@ def register_component(
         )
 
 
-def get_component(component_name: str) -> CustomWorkflowComponent:
+def get_component(component_name: str) -> Components:
     """
     Get the registered workflow component by component name.
 
@@ -91,7 +104,7 @@ def get_component(component_name: str) -> CustomWorkflowComponent:
     return component
 
 
-def deregister_component(component: Union[CustomWorkflowComponent, str]) -> None:
+def deregister_component(component: Union[Components, str]) -> None:
     """
     Deregister the workflow component from QCSubmit.
 
@@ -103,7 +116,7 @@ def deregister_component(component: Union[CustomWorkflowComponent, str]) -> None
     """
 
     if issubclass(type(component), CustomWorkflowComponent):
-        component_name = component.component_name.lower()
+        component_name = component.type.lower()
 
     else:
         component_name = component.lower()
@@ -115,7 +128,7 @@ def deregister_component(component: Union[CustomWorkflowComponent, str]) -> None
         )
 
 
-def list_components() -> List[CustomWorkflowComponent]:
+def list_components() -> List[Components]:
     """
     Get a list of all of the currently registered workflow components.
 

--- a/openff/qcsubmit/workflow_components/base_component.py
+++ b/openff/qcsubmit/workflow_components/base_component.py
@@ -1,97 +1,61 @@
 import abc
-from typing import Any, Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 
 import tqdm
 from openff.toolkit.topology import Molecule
 from openff.toolkit.utils.toolkits import OpenEyeToolkitWrapper, RDKitToolkitWrapper
-from pydantic import BaseModel, Field, validator
-from pydantic.main import ModelMetaclass
+from pydantic import BaseModel, Field, PrivateAttr, validator
 from qcelemental.util import which_import
+from typing_extensions import Literal
 
 from openff.qcsubmit.common_structures import ComponentProperties
 from openff.qcsubmit.datasets import ComponentResult
 
 
-class InheritSlots(ModelMetaclass):
-
-    # This allows subclasses of CustomWorkFlowComponentto inherit __slots__
-    def __new__(mcs, name, bases, namespace):
-
-        slots = set(namespace.pop("__slots__", tuple()))
-
-        for base in bases:
-            if hasattr(base, "__slots__"):
-                slots.update(base.__slots__)
-
-        if "__dict__" in slots:
-            slots.remove("__dict__")
-
-        namespace["__slots__"] = tuple(slots)
-
-        return ModelMetaclass.__new__(mcs, name, bases, namespace)
-
-
-class CustomWorkflowComponent(BaseModel, abc.ABC, metaclass=InheritSlots):
+class CustomWorkflowComponent(BaseModel, abc.ABC):
     """
     This is an abstract base class which should be used to create all workflow components, following the design of this
     class should allow users to easily create new work flow components with out needing to change much of the dataset
     factory code
     """
 
-    component_name: str = Field(
-        ..., description="The name of the component which should match the class name."
-    )
-    component_description: str = Field(
-        ...,
-        description="A short description of what the component will do to the molecules.",
-    )
-    component_fail_message: str = Field(
-        ...,
-        description="A short description with hints on why the molecule may have caused an error in this workflow component.",
-    )
-    _properties: ComponentProperties = Field(
-        ...,
-        description="The internal runtime properties of the component which can not be changed, these indecate if the component can be ran in parallel and if it may produce duplicate molecules.",
-    )
-    _cache: Dict
-
     class Config:
+        allow_mutation = True
         validate_assignment = True
-        arbitrary_types_allowed = True
 
-    # this is a pydantic workaround to add private variables taken from
-    # https://github.com/samuelcolvin/pydantic/issues/655
-    __slots__ = [
-        "_cache",
-    ]
+    component_name: Literal["CustomWorkflowComponent"] = Field(
+        "CustomWorkflowComponent",
+        description="The name of the component which should match the class name.",
+    )
+    # new pydantic private attr is loaded into slots
+    _cache: Dict = PrivateAttr(default={})
 
-    def __init__(self, *args, **kwargs):
-        super(CustomWorkflowComponent, self).__init__(*args, **kwargs)
-        self._cache = {}
+    @classmethod
+    @abc.abstractmethod
+    def description(cls) -> str:
+        """Returns a friendly description of the workflow component."""
+        ...
 
-    def __setattr__(self, attr: str, value: Any) -> None:
-        """
-        Overwrite the Pydantic setattr to configure the handling of our __slots___
-        """
-        if attr in self.__slots__:
-            object.__setattr__(self, attr, value)
-        else:
-            super(CustomWorkflowComponent, self).__setattr__(attr, value)
+    @classmethod
+    @abc.abstractmethod
+    def fail_reason(cls) -> str:
+        """Returns a friendly description of why a molecule would fail to pass the component."""
+        ...
 
-    # getstate and setstate are needed since private instance members (_*)
-    # are not included in pickles by Pydantic at the current moment. Force them
-    # to be added here. This is needed for multiprocessing support.
-    def __getstate__(self):
-        return (
-            super().__getstate__(),
-            {slot: getattr(self, slot) for slot in self.__slots__},
+    @classmethod
+    @abc.abstractmethod
+    def properties(cls) -> ComponentProperties:
+        """Returns the runtime properties of the component such as parallel safe."""
+        ...
+
+    @classmethod
+    def inifo(cls) -> Dict[str, str]:
+        """Returns a dictionary of the friendly descriptions of the class."""
+        return dict(
+            name=cls.__name__,
+            description=cls.description(),
+            fail_reason=cls.fail_reason(),
         )
-
-    def __setstate__(self, state):
-        super().__setstate__(state[0])
-        d = state[1]
-        for slot in d:
-            setattr(self, slot, d[slot])
 
     @classmethod
     @abc.abstractmethod
@@ -160,7 +124,9 @@ class CustomWorkflowComponent(BaseModel, abc.ABC, metaclass=InheritSlots):
         # Use a Pool to get around the GIL. As long as self does not contain
         # too much data, this should be efficient.
 
-        if (processors is None or processors > 1) and self._properties.process_parallel:
+        if (
+            processors is None or processors > 1
+        ) and self.properties().process_parallel:
 
             from multiprocessing.pool import Pool
 
@@ -225,7 +191,7 @@ class CustomWorkflowComponent(BaseModel, abc.ABC, metaclass=InheritSlots):
             component_name=self.component_name,
             component_description=self.dict(),
             component_provenance=self.provenance(),
-            skip_unique_check=not self._properties.produces_duplicates,
+            skip_unique_check=not self.properties().produces_duplicates,
             **kwargs,
         )
 
@@ -245,10 +211,13 @@ class ToolkitValidator(BaseModel):
         "openeye",
         description="The name of the toolkit which should be used in this component.",
     )
-    _toolkits: Dict = {"rdkit": RDKitToolkitWrapper, "openeye": OpenEyeToolkitWrapper}
+    _toolkits: ClassVar[Dict] = {
+        "rdkit": RDKitToolkitWrapper,
+        "openeye": OpenEyeToolkitWrapper,
+    }
 
     @validator("toolkit")
-    def _check_toolkit(cls, toolkit):
+    def _check_toolkit(cls, toolkit: str) -> str:
         """
         Make sure that toolkit is one of the supported types in the OFFTK.
         """

--- a/openff/qcsubmit/workflow_components/base_component.py
+++ b/openff/qcsubmit/workflow_components/base_component.py
@@ -23,7 +23,7 @@ class CustomWorkflowComponent(BaseModel, abc.ABC):
         allow_mutation = True
         validate_assignment = True
 
-    component_name: Literal["CustomWorkflowComponent"] = Field(
+    type: Literal["CustomWorkflowComponent"] = Field(
         "CustomWorkflowComponent",
         description="The name of the component which should match the class name.",
     )
@@ -49,7 +49,7 @@ class CustomWorkflowComponent(BaseModel, abc.ABC):
         ...
 
     @classmethod
-    def inifo(cls) -> Dict[str, str]:
+    def info(cls) -> Dict[str, str]:
         """Returns a dictionary of the friendly descriptions of the class."""
         return dict(
             name=cls.__name__,
@@ -141,7 +141,7 @@ class CustomWorkflowComponent(BaseModel, abc.ABC):
                     work_list,
                     total=len(work_list),
                     ncols=80,
-                    desc="{:30s}".format(self.component_name),
+                    desc="{:30s}".format(self.type),
                     disable=not verbose,
                 ):
                     work = work.get()
@@ -155,7 +155,7 @@ class CustomWorkflowComponent(BaseModel, abc.ABC):
                 molecules,
                 total=len(molecules),
                 ncols=80,
-                desc="{:30s}".format(self.component_name),
+                desc="{:30s}".format(self.type),
                 disable=not verbose,
             ):
                 work = self._apply([molecule])
@@ -188,7 +188,7 @@ class CustomWorkflowComponent(BaseModel, abc.ABC):
         """
 
         result = ComponentResult(
-            component_name=self.component_name,
+            component_name=self.type,
             component_description=self.dict(),
             component_provenance=self.provenance(),
             skip_unique_check=not self.properties().produces_duplicates,

--- a/openff/qcsubmit/workflow_components/conformer_generation.py
+++ b/openff/qcsubmit/workflow_components/conformer_generation.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 import simtk.unit as unit
 from openff.toolkit.topology import Molecule
 from pydantic import Field
+from typing_extensions import Literal
 
 from openff.qcsubmit.common_structures import ComponentProperties
 from openff.qcsubmit.datasets import ComponentResult
@@ -21,13 +22,7 @@ class StandardConformerGenerator(ToolkitValidator, CustomWorkflowComponent):
         [ToolkitValidator][qcsubmit.workflow_components.base_component.ToolkitValidator] mixin.
     """
 
-    # standard components which must be defined
-    component_name = "StandardConformerGenerator"
-    component_description = "Generate conformations for the given molecules"
-    component_fail_message = "Conformers could not be generated"
-
-    # custom components for this class
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=False)
+    component_name: Literal["StandardConformerGenerator"] = "StandardConformerGenerator"
 
     rms_cutoff: Optional[float] = Field(
         None,
@@ -39,6 +34,18 @@ class StandardConformerGenerator(ToolkitValidator, CustomWorkflowComponent):
     clear_existing: bool = Field(
         True, description="If any pre-existing conformers should be kept."
     )
+
+    @classmethod
+    def description(cls) -> str:
+        return "Generate conformations for the given molecules."
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "Conformers could not be generated."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=False)
 
     def _apply_init(self, result: ComponentResult) -> None:
         """

--- a/openff/qcsubmit/workflow_components/conformer_generation.py
+++ b/openff/qcsubmit/workflow_components/conformer_generation.py
@@ -22,7 +22,7 @@ class StandardConformerGenerator(ToolkitValidator, CustomWorkflowComponent):
         [ToolkitValidator][qcsubmit.workflow_components.base_component.ToolkitValidator] mixin.
     """
 
-    component_name: Literal["StandardConformerGenerator"] = "StandardConformerGenerator"
+    type: Literal["StandardConformerGenerator"] = "StandardConformerGenerator"
 
     rms_cutoff: Optional[float] = Field(
         None,

--- a/openff/qcsubmit/workflow_components/filters.py
+++ b/openff/qcsubmit/workflow_components/filters.py
@@ -28,7 +28,7 @@ class MolecularWeightFilter(BasicSettings, CustomWorkflowComponent):
     Filters molecules based on the minimum and maximum allowed molecular weights.
     """
 
-    component_name: Literal["MolecularWeightFilter"] = "MolecularWeightFilter"
+    type: Literal["MolecularWeightFilter"] = "MolecularWeightFilter"
     minimum_weight: int = Field(
         130,
         description="The minimum allowed molecule weight  default value taken from the openeye blockbuster filter",
@@ -116,7 +116,7 @@ class ElementFilter(BasicSettings, CustomWorkflowComponent):
         ```
     """
 
-    component_name: Literal["ElementFilter"] = "ElementFilter"
+    type: Literal["ElementFilter"] = "ElementFilter"
     allowed_elements: List[Union[int, str]] = Field(
         [
             "H",
@@ -223,7 +223,7 @@ class CoverageFilter(BasicSettings, CustomWorkflowComponent):
         A value of None in a list will let all molecules through.
     """
 
-    component_name: Literal["CoverageFilter"] = "CoverageFilter"
+    type: Literal["CoverageFilter"] = "CoverageFilter"
     allowed_ids: Optional[Set[str]] = Field(
         None,
         description="The SMIRKS parameter ids of the parameters which are allowed to be exercised by the molecules. Molecules should use atleast one of these ids to be passed by the component.",
@@ -347,7 +347,7 @@ class RotorFilter(BasicSettings, CustomWorkflowComponent):
         openforcefield.topology.Molecule class.
     """
 
-    component_name: Literal["RotorFilter"] = "RotorFilter"
+    type: Literal["RotorFilter"] = "RotorFilter"
     maximum_rotors: Optional[int] = Field(
         4,
         description="The maximum number of rotatable bonds allowed in the molecule, if `None` the molecule has no maximum limit on rotatable bonds.",
@@ -418,7 +418,7 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
         * If tag_dihedrals is set to true any smarts pattern tagging 4 atoms in a torsion will be prepared for a torsiondrive.
     """
 
-    component_name: Literal["SmartsFilter"] = "SmartsFilter"
+    type: Literal["SmartsFilter"] = "SmartsFilter"
     allowed_substructures: Optional[List[str]] = Field(
         None,
         description="The list of allowed substructures which should be tagged with indicies.",
@@ -529,7 +529,7 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
     """
 
     # standard components which must be defined
-    component_name: Literal["RMSDCutoffConformerFilter"] = "RMSDCutoffConformerFilter"
+    type: Literal["RMSDCutoffConformerFilter"] = "RMSDCutoffConformerFilter"
     # custom components for this class
     cutoff: float = Field(-1.0, description="The RMSD cut off in angstroms.")
 

--- a/openff/qcsubmit/workflow_components/filters.py
+++ b/openff/qcsubmit/workflow_components/filters.py
@@ -12,6 +12,7 @@ from openff.toolkit.typing.chemistry.environment import (
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from pydantic import Field, validator
 from rdkit.Chem.rdMolAlign import AlignMol
+from typing_extensions import Literal
 
 from openff.qcsubmit.common_structures import ComponentProperties, TorsionIndexer
 from openff.qcsubmit.datasets import ComponentResult
@@ -27,12 +28,7 @@ class MolecularWeightFilter(BasicSettings, CustomWorkflowComponent):
     Filters molecules based on the minimum and maximum allowed molecular weights.
     """
 
-    component_name = "MolecularWeightFilter"
-    component_description = (
-        "Molecules are filtered based on the allowed molecular weights."
-    )
-    component_fail_message = "Molecule weight was not in the specified region."
-
+    component_name: Literal["MolecularWeightFilter"] = "MolecularWeightFilter"
     minimum_weight: int = Field(
         130,
         description="The minimum allowed molecule weight  default value taken from the openeye blockbuster filter",
@@ -41,9 +37,18 @@ class MolecularWeightFilter(BasicSettings, CustomWorkflowComponent):
         781,
         description="The maximum allow molecule weight, default taken from the openeye blockbuster filter.",
     )
-    _properties: ComponentProperties = ComponentProperties(
-        process_parallel=True, produces_duplicates=False
-    )
+
+    @classmethod
+    def description(cls) -> str:
+        return "Molecules are filtered based on the allowed molecular weights."
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "Molecule weight was not in the specified region."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=False)
 
     def _apply(self, molecules: List[Molecule]) -> ComponentResult:
         """
@@ -111,14 +116,7 @@ class ElementFilter(BasicSettings, CustomWorkflowComponent):
         ```
     """
 
-    component_name = "ElementFilter"
-    component_description = (
-        "Filter out molecules who contain elements not in the allowed element list"
-    )
-    component_fail_message = (
-        "Molecule contained elements not in the allowed elements list"
-    )
-
+    component_name: Literal["ElementFilter"] = "ElementFilter"
     allowed_elements: List[Union[int, str]] = Field(
         [
             "H",
@@ -134,11 +132,23 @@ class ElementFilter(BasicSettings, CustomWorkflowComponent):
         ],
         description="The list of allowed elements as symbols or atomic number ints.",
     )
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=False)
-
     _check_elements = validator("allowed_elements", each_item=True, allow_reuse=True)(
         check_allowed_elements
     )
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "Filter out molecules who contain elements not in the allowed element list."
+        )
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "Molecules contained elements not in the allowed elements list."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=False)
 
     def _apply_init(self, result: ComponentResult) -> None:
 
@@ -213,12 +223,7 @@ class CoverageFilter(BasicSettings, CustomWorkflowComponent):
         A value of None in a list will let all molecules through.
     """
 
-    component_name = "CoverageFilter"
-    component_description = (
-        "Filter the molecules based on the requested FF allowed parameters."
-    )
-    component_fail_message = "The molecule was typed with disallowed parameters."
-
+    component_name: Literal["CoverageFilter"] = "CoverageFilter"
     allowed_ids: Optional[Set[str]] = Field(
         None,
         description="The SMIRKS parameter ids of the parameters which are allowed to be exercised by the molecules. Molecules should use atleast one of these ids to be passed by the component.",
@@ -235,7 +240,18 @@ class CoverageFilter(BasicSettings, CustomWorkflowComponent):
         False,
         description="If we should tag any dihedral ids exercised for torsion driving.",
     )
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=False)
+
+    @classmethod
+    def description(cls) -> str:
+        return "Filter the molecules based on the requested FF allowed parameters."
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "The molecule was typed with disallowed parameters."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=False)
 
     def _apply_init(self, result: ComponentResult) -> None:
 
@@ -327,18 +343,11 @@ class RotorFilter(BasicSettings, CustomWorkflowComponent):
     Filters molecules based on the maximum allowed number of rotatable bonds.
 
     Note:
-        Rotatable bonds are non terminal torsions found using the `find_rotatable_bonds` method of the
+        Rotatable bonds are torsions found using the `find_rotatable_bonds` method of the
         openforcefield.topology.Molecule class.
     """
 
-    component_name = "RotorFilter"
-    component_description = (
-        "Filter the molecules based on the maximum number of allowed rotatable bonds."
-    )
-    component_fail_message = "The molecule has too many rotatable bonds."
-
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=False)
-
+    component_name: Literal["RotorFilter"] = "RotorFilter"
     maximum_rotors: Optional[int] = Field(
         4,
         description="The maximum number of rotatable bonds allowed in the molecule, if `None` the molecule has no maximum limit on rotatable bonds.",
@@ -347,6 +356,18 @@ class RotorFilter(BasicSettings, CustomWorkflowComponent):
         None,
         description="The minimum number of rotatble bonds allowed in the molecule, if `None` the molecule has no limit to the minimum number of rotatble bonds.",
     )
+
+    @classmethod
+    def description(cls) -> str:
+        return "Filter the molecules based on the maximum number of allowed rotatable bonds."
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "The molecule has too many rotatable bonds."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=False)
 
     def _apply_init(self, result: ComponentResult) -> None:
         """
@@ -397,13 +418,7 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
         * If tag_dihedrals is set to true any smarts pattern tagging 4 atoms in a torsion will be prepared for a torsiondrive.
     """
 
-    component_name = "SmartsFilter"
-    component_description = "Filter molecules based on the given smarts patterns."
-    component_fail_message = (
-        "The molecule did/didn't contain the given smarts patterns."
-    )
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=False)
-
+    component_name: Literal["SmartsFilter"] = "SmartsFilter"
     allowed_substructures: Optional[List[str]] = Field(
         None,
         description="The list of allowed substructures which should be tagged with indicies.",
@@ -415,6 +430,18 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
         False,
         description="If any dihedrals included in the allowed smarts should also be tagged for torsion driving.",
     )
+
+    @classmethod
+    def description(cls) -> str:
+        return "Filter molecules based on the given smarts patterns."
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "The molecule did/didn't contain the given smarts patterns."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=False)
 
     @validator("allowed_substructures", "filtered_substructures", each_item=True)
     def _check_environments(cls, environment):
@@ -502,15 +529,21 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
     """
 
     # standard components which must be defined
-    component_name = "RMSDCutoffConformerFilter"
-    component_description = (
-        "Filter conformations for the given molecules using a RMSD cutoff"
-    )
-    component_fail_message = "Could not filter the conformers using RMSD"
-
+    component_name: Literal["RMSDCutoffConformerFilter"] = "RMSDCutoffConformerFilter"
     # custom components for this class
     cutoff: float = Field(-1.0, description="The RMSD cut off in angstroms.")
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=False)
+
+    @classmethod
+    def description(cls) -> str:
+        return "Filter conformations for the given molecules using a RMSD cutoff."
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "Could not filter the conformers using RMSD."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=False)
 
     def _prune_conformers(self, molecule: Molecule) -> None:
 

--- a/openff/qcsubmit/workflow_components/fragmentation.py
+++ b/openff/qcsubmit/workflow_components/fragmentation.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Union
 from openff.toolkit.topology import Molecule
 from pydantic import Field, validator
 from qcelemental.util import which_import
+from typing_extensions import Literal
 
 from openff.qcsubmit.common_structures import ComponentProperties, TorsionIndexer
 from openff.qcsubmit.datasets import ComponentResult
@@ -22,12 +23,7 @@ class WBOFragmenter(ToolkitValidator, CustomWorkflowComponent):
     For more information see <https://github.com/openforcefield/fragmenter>.
     """
 
-    component_name = "WBOFragmenter"
-    component_description = (
-        "Fragment a molecule across all rotatble bonds using the WBO fragmenter."
-    )
-    component_fail_message = "The molecule could not be fragmented correctly."
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=True)
+    component_name: Literal["WBOFragmenter"] = "WBOFragmenter"
     threshold: float = Field(
         0.03,
         description="The WBO error threshold between the parent and the fragment value, the fragmentation will stop when the difference between the fragment and parent is less than this value.",
@@ -45,6 +41,20 @@ class WBOFragmenter(ToolkitValidator, CustomWorkflowComponent):
         False,
         description="If the parent molecule should also be included in the output.",
     )
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "Fragment a molecule across all rotatable bonds using the WBO fragmenter."
+        )
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "The molecule could not be fragmented correctly."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=True)
 
     @validator("functional_groups")
     def check_functional_groups(cls, functional_group):

--- a/openff/qcsubmit/workflow_components/fragmentation.py
+++ b/openff/qcsubmit/workflow_components/fragmentation.py
@@ -23,7 +23,7 @@ class WBOFragmenter(ToolkitValidator, CustomWorkflowComponent):
     For more information see <https://github.com/openforcefield/fragmenter>.
     """
 
-    component_name: Literal["WBOFragmenter"] = "WBOFragmenter"
+    type: Literal["WBOFragmenter"] = "WBOFragmenter"
     threshold: float = Field(
         0.03,
         description="The WBO error threshold between the parent and the fragment value, the fragmentation will stop when the difference between the fragment and parent is less than this value.",

--- a/openff/qcsubmit/workflow_components/state_enumeration.py
+++ b/openff/qcsubmit/workflow_components/state_enumeration.py
@@ -6,6 +6,7 @@ from typing import List
 from openff.toolkit.topology import Molecule
 from openff.toolkit.utils.toolkits import OpenEyeToolkitWrapper
 from pydantic import Field
+from typing_extensions import Literal
 
 from openff.qcsubmit.common_structures import ComponentProperties
 from openff.qcsubmit.datasets import ComponentResult
@@ -25,15 +26,23 @@ class EnumerateTautomers(ToolkitValidator, CustomWorkflowComponent):
         [ToolkitValidator][qcsubmit.workflow_components.base_component.ToolkitValidator] mixin.
     """
 
-    component_name = "EnumerateTautomers"
-    component_description = "Enumerate the tautomers of a molecule if possible, if none are found return the input."
-    component_fail_message = "The molecule tautomers could not be enumerated."
-
+    component_name: Literal["EnumerateTautomers"] = "EnumerateTautomers"
     # custom settings for the class
     max_tautomers: int = Field(
         20, description="The maximum number of tautomers that should be generated."
     )
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=True)
+
+    @classmethod
+    def description(cls) -> str:
+        return "Enumerate the tautomers of a molecule if possible, returning the input plus any new molecules."
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "The molecule tautomers could not be enumerated."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=True)
 
     def _apply_init(self, result: ComponentResult) -> None:
         """
@@ -85,14 +94,7 @@ class EnumerateStereoisomers(ToolkitValidator, CustomWorkflowComponent):
         [ToolkitValidator][qcsubmit.workflow_components.base_component.ToolkitValidator] mixin.
     """
 
-    component_name = "EnumerateStereoisomers"
-    component_description = (
-        "Enumerate the stereo centers and bonds of the molecule if possible."
-    )
-    component_fail_message = (
-        "The molecules stereo centers or bonds could not be enumerated"
-    )
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=True)
+    component_name: Literal["EnumerateStereoisomers"] = "EnumerateStereoisomers"
     undefined_only: bool = Field(
         False,
         description="If we should only enumerate parts of the molecule with undefined stereochemistry or all stereochemistry.",
@@ -105,14 +107,25 @@ class EnumerateStereoisomers(ToolkitValidator, CustomWorkflowComponent):
         description="If we should check that the resulting molecules are physically possible by attempting to generate conformers for them.",
     )
 
+    @classmethod
+    def description(cls) -> str:
+        return "Enumerate the stereo centers and bonds of the molecule, returing the input molecule if valid and any new molecules."
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "The molecules stereo centers or bonds could not be enumerated."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=True)
+
     def _apply_init(self, result: ComponentResult) -> None:
 
         self._cache["toolkit"] = self._toolkits[self.toolkit]()
 
     def _apply(self, molecules: List[Molecule]) -> ComponentResult:
         """
-        Enumerate stereo centers and bonds of the input molecule if no isomers are found only the input molecule is
-        returned.
+        Enumerate stereo centers and bonds of the input molecule
 
         Parameters:
             molecules: The list of molecules the component should be applied on.
@@ -161,18 +174,26 @@ class EnumerateProtomers(ToolkitValidator, CustomWorkflowComponent):
         Only Openeye is supported so far.
     """
 
-    component_name = "EnumerateProtomers"
-    component_description = "Enumerate the protomers of the molecule if possible."
-    component_fail_message = "The molecules formal charges could not be enumerated possibly due to a missing toolkit."
-
+    component_name: Literal["EnumerateProtomers"] = "EnumerateProtomers"
     # restrict the allowed toolkits for this module
     toolkit = "openeye"
     _toolkits = {"openeye": OpenEyeToolkitWrapper}
-    _properties = ComponentProperties(process_parallel=True, produces_duplicates=True)
 
     max_states: int = Field(
         10, description="The maximum number of states that should be generated."
     )
+
+    @classmethod
+    def description(cls) -> str:
+        return "Enumerate the protomers of the molecule, returning the input molecule and any new molecules."
+
+    @classmethod
+    def fail_reason(cls) -> str:
+        return "The molecules formal charges could not be enumerated possibly due to a missing toolkit."
+
+    @classmethod
+    def properties(cls) -> ComponentProperties:
+        return ComponentProperties(process_parallel=True, produces_duplicates=True)
 
     def _apply_init(self, result: ComponentResult) -> None:
 
@@ -180,7 +201,7 @@ class EnumerateProtomers(ToolkitValidator, CustomWorkflowComponent):
 
     def _apply(self, molecules: List[Molecule]) -> ComponentResult:
         """
-        Enumerate the formal charges of the molecule if possible if not only the input molecule is returned.
+        Enumerate the formal charges of the molecule.
 
         Parameters:
             molecules: The list of molecules the component should be applied on.

--- a/openff/qcsubmit/workflow_components/state_enumeration.py
+++ b/openff/qcsubmit/workflow_components/state_enumeration.py
@@ -26,7 +26,7 @@ class EnumerateTautomers(ToolkitValidator, CustomWorkflowComponent):
         [ToolkitValidator][qcsubmit.workflow_components.base_component.ToolkitValidator] mixin.
     """
 
-    component_name: Literal["EnumerateTautomers"] = "EnumerateTautomers"
+    type: Literal["EnumerateTautomers"] = "EnumerateTautomers"
     # custom settings for the class
     max_tautomers: int = Field(
         20, description="The maximum number of tautomers that should be generated."
@@ -94,7 +94,7 @@ class EnumerateStereoisomers(ToolkitValidator, CustomWorkflowComponent):
         [ToolkitValidator][qcsubmit.workflow_components.base_component.ToolkitValidator] mixin.
     """
 
-    component_name: Literal["EnumerateStereoisomers"] = "EnumerateStereoisomers"
+    type: Literal["EnumerateStereoisomers"] = "EnumerateStereoisomers"
     undefined_only: bool = Field(
         False,
         description="If we should only enumerate parts of the molecule with undefined stereochemistry or all stereochemistry.",
@@ -174,7 +174,7 @@ class EnumerateProtomers(ToolkitValidator, CustomWorkflowComponent):
         Only Openeye is supported so far.
     """
 
-    component_name: Literal["EnumerateProtomers"] = "EnumerateProtomers"
+    type: Literal["EnumerateProtomers"] = "EnumerateProtomers"
     # restrict the allowed toolkits for this module
     toolkit = "openeye"
     _toolkits = {"openeye": OpenEyeToolkitWrapper}


### PR DESCRIPTION
## Description
This PR updates the `wokflow_components` to use the new pydantic private attributes, we also reduce the amount of information serialised in the models by making any constant fields classmethods such as the description and the properties which decided if the component can be used in parallel. Now the component name is a literal string that distinguishes the component in the workflow and so the workflow is now a list of components that are executed in order. The factory dataset creation logic has also been simplified to remove duplicated code. 

Impliments #42 


## Status
- [x] Ready to go