### PR TITLE
Remove atom maps

### DIFF
--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -12,6 +12,7 @@ from typing import (
     Union,
 )
 
+import numpy as np
 import qcelemental as qcel
 import qcportal as ptl
 import tqdm
@@ -22,6 +23,7 @@ from qcportal.models.common_models import (
     OptimizationSpecification,
     QCSpecification,
 )
+from simtk import unit
 from typing_extensions import Literal
 
 from openff.qcsubmit.common_structures import (
@@ -189,9 +191,9 @@ class ComponentResult:
         Add a molecule to the molecule list after checking that it is not present already. If it is de-duplicate the
         record and condense the conformers and metadata.
         """
-
-        import numpy as np
-        from simtk import unit
+        # always strip the atom map as it is not preserved in a workflow
+        if "atom_map" in molecule.properties:
+            del molecule.properties["atom_map"]
 
         # make a unique molecule hash independent of atom order or conformers
         molecule_hash = molecule.to_inchikey(fixed_hydrogens=True)

--- a/openff/qcsubmit/tests/test_factories.py
+++ b/openff/qcsubmit/tests/test_factories.py
@@ -545,7 +545,8 @@ def test_create_dataset(factory_dataset_type):
     for attr, value in changed_attrs.items():
         setattr(factory, attr, value)
 
-    dataset = factory.create_dataset(dataset_name="test name", molecules=mols, description="Force field test", tagline="A test dataset")
+    dataset = factory.create_dataset(dataset_name="test name", molecules=mols, description="Force field test",
+                                     tagline="A test dataset")
 
     # check the attributes were changed
     for attr, value in changed_attrs.items():
@@ -559,3 +560,13 @@ def test_create_dataset(factory_dataset_type):
     assert dataset.dataset != {}
     assert dataset.filtered != {}
     assert element_filter.type in dataset.filtered_molecules
+
+
+def test_create_dataset_atom_map():
+    """Test creating a dataset with molecules with atom maps."""
+
+    factory = OptimizationDatasetFactory()
+    mol = Molecule.from_smiles("CCCC([O-])=O")
+    mol.properties['atom_map'] = {1: 1, 2: 2, 3: 3, 4: 4}
+    _ = factory.create_dataset(dataset_name="test name", molecules=mol, description="Force field test",
+                               tagline="A test dataset")


### PR DESCRIPTION
## Description
This PR fixes #131 by removing atom maps from molecules once they enter into the workflow. We do this as we can not guarantee that they will survive the various workflow components and can cause unexpected behaviour if they are present when not expected. 

## Status
- [X] Ready to go