### PR TITLE
LowestEnergyFilter

### DIFF
--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -158,7 +158,12 @@ class ResultRecordFilter(ResultFilter, abc.ABC):
 
 
 class ResultRecordGroupFilter(ResultFilter, abc.ABC):
-    """The base class for filters which reduces repeated molecule entries down to a single entry."""
+    """The base class for filters which reduces repeated molecule entries down to a single entry.
+
+    Notes:
+        * This filter will only be applied to basic and optimization datasets.
+        Torsion drive datasets / entries will be skipped.
+    """
 
     @abc.abstractmethod
     def _filter_function(
@@ -203,7 +208,12 @@ class ResultRecordGroupFilter(ResultFilter, abc.ABC):
 
 
 class LowestEnergyFilter(ResultRecordGroupFilter):
-    """Filter the results collection and only keep the lowest energy entries."""
+    """Filter the results collection and only keep the lowest energy entries.
+
+    Notes:
+        * This filter will only be applied to basic and optimization datasets.
+        Torsion drive datasets / entries will be skipped.
+    """
 
     def _filter_function(
         self,

--- a/openff/qcsubmit/tests/results/__init__.py
+++ b/openff/qcsubmit/tests/results/__init__.py
@@ -122,6 +122,7 @@ def mock_optimization_result_collection(
                     initial_molecule=ObjectId(entry.record_id),
                     final_molecule=ObjectId(entry.record_id),
                     status=RecordStatusEnum.complete,
+                    energies=[numpy.random.random()],
                     client=_FractalClient(address=address),
                 ),
                 molecules[address][int(entry.record_id) - 1],

--- a/openff/qcsubmit/tests/results/conftest.py
+++ b/openff/qcsubmit/tests/results/conftest.py
@@ -104,6 +104,21 @@ def optimization_result_collection(monkeypatch) -> OptimizationResultCollection:
 
 
 @pytest.fixture()
+def optimization_result_collection_duplicates(monkeypatch) -> OptimizationResultCollection:
+    """Create a collection with duplicate enetries accross different addresses which can be reduced to a single entry."""
+
+    smiles = {
+        "http://localhost:442": [
+            _smiles_to_molecule(smiles="CCCO")
+        ],
+        "http://localhost:443": [
+            _smiles_to_molecule(smiles="CCCO")
+        ]
+    }
+    return mock_optimization_result_collection(smiles, monkeypatch)
+
+
+@pytest.fixture()
 def torsion_drive_result_collection(monkeypatch) -> TorsionDriveResultCollection:
     """Create a basic collection which can be filtered."""
 

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -14,6 +14,7 @@ from openff.qcsubmit.results.filters import (
     ConnectivityFilter,
     ElementFilter,
     HydrogenBondFilter,
+    LowestEnergyFilter,
     RecordStatusFilter,
     ResultFilter,
     ResultRecordFilter,
@@ -275,3 +276,18 @@ def test_element_filter(basic_result_collection):
     result = element_filter.apply(result_collection=basic_result_collection)
     assert result.n_results == 0
     assert result.n_molecules == 0
+
+
+def test_lowest_energy_filter(optimization_result_collection_duplicates):
+
+    energy_filter = LowestEnergyFilter()
+
+    # should have 2 results
+    assert optimization_result_collection_duplicates.n_results == 2
+    result = energy_filter.apply(result_collection=optimization_result_collection_duplicates)
+
+    # make sure we only have one result
+    assert result.n_molecules == 1
+    assert result.n_results == 1
+
+


### PR DESCRIPTION
## Description
This PR adds the `LowestEnergyFilter` which can be used on Basic and Optimisation results collections to reduce down the number of repeated entries for a molecule to a single entry corresponding to the lowest energy structure. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add tests for this filter


## Status
- [x] Ready to go