### PR TITLE
Fix mocking imports for sphinx doc builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,6 @@ autodoc_default_options = {
 }
 
 autodoc_mock_imports = [
-    'openff.toolkit',
     'rdkit',
 ]
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - ipython
 
     # Standard dependencies
-#  - openff-toolkit-base  MOCKED
+  - openff-toolkit-base
 #  - rdkit                MOCKED
   - pydantic
   - pyyaml


### PR DESCRIPTION
## Description

This PR fixes the API documentation rendering by ensuring the OpenFF toolkit can be imported.

## Status
- [X] Ready to go