### PR TITLE
Make `long_description_url` metadata optional

### DIFF
--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -1025,6 +1025,12 @@ class Metadata(DatasetConfig):
 
         empty_fields = []
         for field in self.__fields__:
+
+            if field == "long_description_url":
+                # The 'long_description_url' is made optional to more easily facilitate
+                # local or private dataset submissions.
+                continue
+
             attr = getattr(self, field)
             if attr is None:
                 empty_fields.append(field)

--- a/openff/qcsubmit/tests/test_common_structures.py
+++ b/openff/qcsubmit/tests/test_common_structures.py
@@ -1,6 +1,9 @@
+import pytest
 from openff.toolkit.topology import Molecule
 
-from openff.qcsubmit.common_structures import MoleculeAttributes
+from openff.qcsubmit.common_structures import Metadata, MoleculeAttributes
+from openff.qcsubmit.exceptions import DatasetInputError
+from openff.qcsubmit.tests import does_not_raise
 
 
 def test_attributes_from_openff_molecule():
@@ -42,3 +45,42 @@ def test_attributes_to_openff_molecule():
     assert isomorphic is True
     # make sure the molecules are in the same order
     assert atom_map == dict((i, i) for i in range(mol.n_atoms))
+
+
+@pytest.mark.parametrize(
+    "metadata, expected_raises",
+    [
+        (
+            Metadata(
+                collection_type="torsiondrive",
+                dataset_name="ABC",
+                short_description="abcdefgh",
+                long_description_url="https://github.com/openforcefield",
+                long_description="abcdefgh",
+                elements={"C", "H"}
+            ),
+            does_not_raise()
+        ),
+        (
+            Metadata(
+                collection_type="torsiondrive",
+                dataset_name="ABC",
+                short_description="abcdefgh",
+                long_description="abcdefgh",
+                elements={"C", "H"}
+            ),
+            does_not_raise()
+        ),
+        (
+            Metadata(),
+            pytest.raises(
+                DatasetInputError,
+                match="The metadata has the following incomplete fields"
+            )
+        )
+    ]
+)
+def test_validate_metadata(metadata, expected_raises):
+
+    with expected_raises:
+        metadata.validate_metadata(raise_errors=True)

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -1179,15 +1179,14 @@ def test_dataset_metadata(dataset_type):
 
     # make a basic dataset
     dataset = dataset_type(dataset_name="Test dataset", dataset_tagline="XXXXXXXX", description="XXXXXXXX")
+    dataset.metadata.short_description = None
 
     # check the metadata
     empty_fields = dataset.metadata.validate_metadata(raise_errors=False)
-    # this should be the only none autofilled field
-    assert empty_fields == ["long_description_url"]
+    assert empty_fields == ["short_description"]
 
     # now make sure the names and types match
     assert dataset.metadata.dataset_name == dataset.dataset_name
-    assert dataset.metadata.short_description == dataset.dataset_tagline
     assert dataset.metadata.long_description == dataset.description
     assert dataset.metadata.collection_type == dataset.type
 

--- a/openff/qcsubmit/tests/test_submissions.py
+++ b/openff/qcsubmit/tests/test_submissions.py
@@ -58,11 +58,14 @@ def test_basic_submissions_single_spec(fractal_compute_server, specification):
                                      tagline="Testing single point datasets",
                                      )
 
+    # force a metadata validation error
+    dataset.metadata.long_description = None
+
     with pytest.raises(DatasetInputError):
         dataset.submit(client=client)
 
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
+    # re-add the description so we can submit the data
+    dataset.metadata.long_description = "Test basics dataset"
 
     # now submit again
     dataset.submit(client=client)
@@ -136,11 +139,14 @@ def test_basic_submissions_multiple_spec(fractal_compute_server):
                                      tagline="Testing single point datasets",
                                      )
 
+    # force a metadata validation error
+    dataset.metadata.long_description = None
+
     with pytest.raises(DatasetInputError):
         dataset.submit(client=client)
 
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
+    # re-add the description so we can submit the data
+    dataset.metadata.long_description = "Test basics dataset"
 
     # now submit again
     dataset.submit(client=client)
@@ -587,11 +593,14 @@ def test_optimization_submissions(fractal_compute_server, specification):
                                      tagline="Testing optimization datasets",
                                      )
 
+    # force a metadata validation error
+    dataset.metadata.long_description = None
+
     with pytest.raises(DatasetInputError):
         dataset.submit(client=client)
 
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
+    # re-add the description so we can submit the data
+    dataset.metadata.long_description = "Test basics dataset"
 
     # now submit again
     dataset.submit(client=client)
@@ -778,11 +787,14 @@ def test_torsiondrive_submissions(fractal_compute_server, specification):
                                      tagline="Testing torsiondrive datasets",
                                      )
 
+    # force a metadata validation error
+    dataset.metadata.long_description = None
+
     with pytest.raises(DatasetInputError):
         dataset.submit(client=client)
 
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
+    # re-add the description so we can submit the data
+    dataset.metadata.long_description = "Test basics dataset"
 
     # now submit again
     dataset.submit(client=client)

--- a/openff/qcsubmit/tests/test_submissions.py
+++ b/openff/qcsubmit/tests/test_submissions.py
@@ -218,11 +218,14 @@ def test_basic_submissions_single_pcm_spec(fractal_compute_server):
                                      tagline="Testing single point datasets with pcm water",
                                      )
 
+    # force a metadata validation error
+    dataset.metadata.long_description = None
+
     with pytest.raises(DatasetInputError):
         dataset.submit(client=client)
 
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
+    # re-add the description so we can submit the data
+    dataset.metadata.long_description = "Test basics dataset"
 
     # now submit again
     dataset.submit(client=client)
@@ -293,7 +296,6 @@ def test_adding_specifications(fractal_compute_server):
     opt_dataset.add_qc_spec(method="openff-1.0.0", basis="smirnoff", program="openmm",
                             spec_description="default openff spec", spec_name="openff-1.0.0")
 
-    opt_dataset.metadata.long_description_url = "https://test.org"
     # submit the optimizations and let the compute run
     opt_dataset.submit(client=client)
     fractal_compute_server.await_results()
@@ -358,9 +360,6 @@ def test_adding_compute(fractal_compute_server, dataset_data):
                                      molecules=mol,
                                      description=f"Testing adding compute to a {dataset_type} dataset",
                                      tagline="tests for adding compute.")
-
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
 
     # now submit again
     dataset.submit(client=client)
@@ -475,8 +474,6 @@ def test_basic_submissions_wavefunction(fractal_compute_server):
                                      description="Test basics dataset",
                                      tagline="Testing single point datasets with wavefunction",
                                      )
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
 
     # submit the dataset
     # now submit again
@@ -545,8 +542,6 @@ def test_optimization_submissions_with_constraints(fractal_compute_server):
     attributes = factory.create_cmiles_metadata(ethane)
     index = ethane.to_smiles()
     dataset.add_molecule(index=index, molecule=ethane, attributes=attributes, constraints=constraints)
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
 
     # now submit again
     dataset.submit(client=client)
@@ -671,11 +666,14 @@ def test_optimization_submissions_with_pcm(fractal_compute_server):
                                      tagline="Testing optimization datasets",
                                      )
 
+    # force a metadata validation error
+    dataset.metadata.long_description = None
+
     with pytest.raises(DatasetInputError):
         dataset.submit(client=client)
 
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
+    # re-add the description so we can submit the data
+    dataset.metadata.long_description = "Test basics dataset"
 
     # now submit again
     dataset.submit(client=client)
@@ -736,8 +734,6 @@ def test_torsiondrive_scan_keywords(fractal_compute_server):
     dataset = factory.create_dataset(dataset_name="Torsiondrive scan keywords", molecules=molecules,
                                      description="Testing scan keywords which overwrite the global settings",
                                      tagline="Testing scan keywords which overwrite the global settings")
-    # now add a mock url so we can submit the data
-    dataset.metadata.long_description_url = "https://test.org"
 
     # now set the keywords
     keys = list(dataset.dataset.keys())
@@ -860,8 +856,6 @@ def test_ignore_errors_all_datasets(fractal_compute_server, factory_type, capsys
                                      tagline="Testing ignore errors datasets",
                                      )
 
-    dataset.metadata.long_description_url = "https://test.org"
-
     # make sure the dataset raises an error here
     with pytest.raises(MissingBasisCoverageError):
         dataset.submit(client=client, ignore_errors=False)
@@ -898,7 +892,6 @@ def test_index_not_changed(fractal_compute_server, factory_type):
                                      tagline="Testing index changes datasets",
                                      )
 
-    dataset.metadata.long_description_url = "https://test.org"
     # now change the index name to something unique
     entry = dataset.dataset.pop(list(dataset.dataset.keys())[0])
     entry.index = "my_unique_index"
@@ -938,8 +931,6 @@ def test_adding_dataset_entry_fail(fractal_compute_server, factory_type, capsys)
                                      tagline="Testing ignore errors datasets",
                                      )
 
-    dataset.metadata.long_description_url = "https://test.org"
-
     # make sure all expected index get submitted
     dataset.submit(client=client, verbose=True)
     info = capsys.readouterr()
@@ -974,8 +965,6 @@ def test_expanding_compute(fractal_compute_server, factory_type):
                                      description="Test compute expansion",
                                      tagline="Testing compute expansion",
                                      )
-
-    dataset.metadata.long_description_url = "https://test.org"
 
     # make sure all expected index get submitted
     dataset.submit(client=client)


### PR DESCRIPTION
## Description

This PR makes the `Metadata.long_description_url` optional as it is likely unneeded for private and local submissions.

## Status
- [X] Ready to go