### PR TITLE
Fix retrieving data from snowflake server

### DIFF
--- a/openff/qcsubmit/results/caching.py
+++ b/openff/qcsubmit/results/caching.py
@@ -61,7 +61,18 @@ def batched_indices(indices: List[T], batch_size: int) -> List[List[T]]:
 @lru_cache()
 def cached_fractal_client(address: str) -> FractalClient:
     """Returns a cached copy of a fractal client."""
-    return FractalClient(address)
+
+    try:
+
+        return FractalClient(address)
+
+    except ConnectionRefusedError as e:
+
+        # Try to handle the case when connecting to a local snowflake.
+        try:
+            return FractalClient(address, verify=False)
+        except ConnectionRefusedError:
+            raise e
 
 
 def _cached_client_query(

--- a/openff/qcsubmit/tests/results/test_caching.py
+++ b/openff/qcsubmit/tests/results/test_caching.py
@@ -18,11 +18,28 @@ from openff.qcsubmit.results.caching import (
     cached_query_optimization_results,
     cached_query_procedures,
     cached_query_torsion_drive_results,
+    cached_fractal_client,
 )
 
 
 def test_batched_indices():
     assert batched_indices([1, 2, 3, 4], 3) == [[1, 2, 3], [4]]
+
+
+def test_cached_fractal_client_bad_address():
+
+    with pytest.raises(ConnectionRefusedError):
+        cached_fractal_client("http://localhost:1234/")
+
+
+def test_cached_fractal_client_snowflake():
+
+    from qcfractal import FractalSnowflake
+
+    snowflake = FractalSnowflake(start_server=False)
+    client = cached_fractal_client(snowflake.client().address)
+
+    assert client is not None
 
 
 def test_cached_query_procedures(public_client):

--- a/openff/qcsubmit/tests/results/test_caching.py
+++ b/openff/qcsubmit/tests/results/test_caching.py
@@ -13,12 +13,12 @@ from openff.qcsubmit.results.caching import (
     _molecule_cache,
     _record_cache,
     batched_indices,
+    cached_fractal_client,
     cached_query_basic_results,
     cached_query_molecules,
     cached_query_optimization_results,
     cached_query_procedures,
     cached_query_torsion_drive_results,
-    cached_fractal_client,
 )
 
 


### PR DESCRIPTION
## Description

This PR fixes a bug where data could not be retrieved from a local QCFractal snowflake due to the client verification failing and hence the connection being refused.

## Status
- [X] Ready to go