### PR TITLE
Expose keywords via the QCSpec

### DIFF
--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -10,7 +10,18 @@ from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple, Union
 import numpy as np
 import qcportal as ptl
 from openff.toolkit.topology import Molecule
-from pydantic import BaseModel, Field, HttpUrl, PositiveInt, constr, validator
+from pydantic import (
+    BaseModel,
+    Field,
+    HttpUrl,
+    PositiveInt,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    constr,
+    validator,
+)
 from qcelemental import constants
 from qcelemental.models.results import WavefunctionProtocolEnum
 from qcportal.models.common_models import DriverEnum
@@ -343,6 +354,14 @@ class QCSpec(ResultsConfig):
         None,
         description="If PCM is to be used with psi4 this is the full description of the settings that should be used.",
     )
+    keywords: Optional[
+        Dict[str, Union[StrictStr, StrictInt, StrictFloat, StrictBool]]
+    ] = Field(
+        None,
+        description="An optional set of program specific computational keywords that "
+        "should be passed to the program. These may include, for example, DFT grid "
+        "settings.",
+    )
 
     def __init__(
         self,
@@ -353,6 +372,9 @@ class QCSpec(ResultsConfig):
         spec_description: str = "Standard OpenFF optimization quantum chemistry specification.",
         store_wavefunction: WavefunctionProtocolEnum = WavefunctionProtocolEnum.none,
         implicit_solvent: Optional[PCMSettings] = None,
+        keywords: Optional[
+            Dict[str, Union[StrictStr, StrictInt, StrictFloat, StrictBool]]
+        ] = None,
     ):
         """
         Validate the combination of method, basis and program.
@@ -438,6 +460,7 @@ class QCSpec(ResultsConfig):
             spec_description=spec_description,
             store_wavefunction=store_wavefunction,
             implicit_solvent=implicit_solvent,
+            keywords=keywords,
         )
 
     def dict(
@@ -518,6 +541,9 @@ class QCSpecificationHandler(BaseModel):
         store_wavefunction: str = "none",
         overwrite: bool = False,
         implicit_solvent: Optional[PCMSettings] = None,
+        keywords: Optional[
+            Dict[str, Union[StrictStr, StrictInt, StrictFloat, StrictBool]]
+        ] = None,
     ) -> None:
         """
         Add a new qcspecification to the factory which will be applied to the dataset.
@@ -531,6 +557,8 @@ class QCSpecificationHandler(BaseModel):
             store_wavefunction: what parts of the wavefunction that should be saved
             overwrite: If there is a spec under this name already overwrite it
             implicit_solvent: The implicit solvent settings if it is to be used.
+            keywords: Program specific computational keywords that should be passed to
+                the program
         """
         spec = QCSpec(
             method=method,
@@ -540,6 +568,7 @@ class QCSpecificationHandler(BaseModel):
             spec_description=spec_description,
             store_wavefunction=store_wavefunction,
             implicit_solvent=implicit_solvent,
+            keywords=keywords,
         )
 
         if spec_name not in self.qc_specifications:

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -980,8 +980,18 @@ class _BaseDataset(abc.ABC, CommonBase):
         data = self.dict(include={"maxiter", "scf_properties"})
         # account for implicit solvent
         if spec.implicit_solvent is not None:
+
+            if spec.program.lower() != "psi4":
+
+                raise NotImplementedError(
+                    "Implicit solvent is currently only supported when using psi4."
+                )
+
             data["pcm"] = True
             data["pcm__input"] = spec.implicit_solvent.to_string()
+
+        if spec.keywords is not None:
+            data.update(spec.keywords)
 
         return ptl.models.KeywordSet(values=data)
 

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -627,6 +627,32 @@ def test_scf_prop_validation():
         dataset.scf_properties = ["ddec_charges"]
 
 
+@pytest.mark.parametrize(
+    "keywords",
+    [None, {"keyword-1": True, "keyword-2": 1, "keyword-3": 1.5, "keyword-4": "1.5"}]
+)
+def test_keywords_detected(keywords):
+    """
+    Make sure unsupported scf properties are not allowed into a dataset.
+    """
+    dataset = BasicDataset(
+        dataset_name="Test dataset", dataset_tagline="XXXXXXXX", description="XXXXXXXX",
+    )
+    dataset.add_qc_spec(
+        "hf", "6-31G", "psi4", "XXXXXXXX", "XXXXXXXX", keywords=keywords
+    )
+
+    qc_spec = dataset.qc_specifications["XXXXXXXX"]
+    assert qc_spec.keywords == keywords
+
+    portal_keywords = dataset._get_spec_keywords(qc_spec)
+
+    for key, expected_value in {} if keywords is None else keywords.items():
+
+        assert key in portal_keywords.values
+        assert portal_keywords.values[key] == expected_value
+
+
 def test_add_molecule_no_extras():
     """
     Test that adding a molecule with no extras automatically updates the extras to include the cmiles and c1 symmetry.


### PR DESCRIPTION
## Description

This PR adds the ability to add optional `keywords` to datasets via the associated `QCSpec` specifications.

## Status
- [X] Ready to go