### PR TITLE
Toolkit registry

### DIFF
--- a/openff/qcsubmit/tests/test_workflow_components.py
+++ b/openff/qcsubmit/tests/test_workflow_components.py
@@ -6,7 +6,12 @@ from typing import Dict, List
 import pytest
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
-from openff.toolkit.utils.toolkits import OpenEyeToolkitWrapper, RDKitToolkitWrapper
+from openff.toolkit.utils.toolkits import (
+    GLOBAL_TOOLKIT_REGISTRY,
+    OpenEyeToolkitWrapper,
+    RDKitToolkitWrapper,
+    ToolkitRegistry,
+)
 from pydantic import ValidationError
 from typing_extensions import Literal
 
@@ -158,10 +163,10 @@ def test_custom_component():
         def properties(cls) -> ComponentProperties:
             return ComponentProperties(process_parallel=True, produces_duplicates=True)
 
-        def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+        def _apply(self, molecules: List[Molecule], toolkit_registry) -> ComponentResult:
             pass
 
-        def provenance(self) -> Dict:
+        def provenance(self, toolkit_registry) -> Dict:
             return {"test": "version1"}
 
         @classmethod
@@ -172,93 +177,59 @@ def test_custom_component():
     assert test.component_name == "TestComponent"
     assert test.description() == "Test component"
     assert test.fail_reason() == "Test fail"
-    assert {"test": "version1"} == test.provenance()
+    assert {"test": "version1"} == test.provenance(GLOBAL_TOOLKIT_REGISTRY)
     assert TestComponent.info() == {"name": "TestComponent", "description": "Test component", "fail_reason": "Test fail"}
 
 
-@pytest.mark.parametrize(
-    "toolkit",
-    [
-        pytest.param(("openeye", OpenEyeToolkitWrapper), id="openeye"),
-        pytest.param(("rdkit", RDKitToolkitWrapper), id="rdkit"),
-    ],
-)
-def test_toolkit_mixin(toolkit):
+def test_toolkit_mixin():
     """
     Make sure the pydantic ToolkitValidator mixin is working correctly, it should provide provenance and toolkit name
     validation.
     """
 
-    toolkit_name, toolkit_class = toolkit
-    if toolkit_class.is_available():
+    class TestClass(ToolkitValidator, CustomWorkflowComponent):
+        """Should not need to implement the provenance."""
 
-        class TestClass(ToolkitValidator, CustomWorkflowComponent):
-            """Should not need to implement the provenance."""
+        component_name: Literal["TestClass"] = "TestClass"
 
-            component_name: Literal["TestClass"] = "TestClass"
+        @classmethod
+        def description(cls) -> str:
+            return "ToolkitValidator test class."
 
-            @classmethod
-            def description(cls) -> str:
-                return "ToolkitValidator test class."
+        @classmethod
+        def fail_reason(cls) -> str:
+            return "Test fail"
 
-            @classmethod
-            def fail_reason(cls) -> str:
-                return "Test fail"
+        @classmethod
+        def properties(cls) -> ComponentProperties:
+            return ComponentProperties(process_parallel=True, produces_duplicates=True)
 
-            @classmethod
-            def properties(cls) -> ComponentProperties:
-                return ComponentProperties(process_parallel=True, produces_duplicates=True)
+        def _apply(self, molecules: List[Molecule], toolkit_registry) -> ComponentResult:
+            pass
 
-            def _apply(self, molecules: List[Molecule]) -> ComponentResult:
-                pass
+    test = TestClass()
 
-        test = TestClass()
-        with pytest.raises(ValidationError):
-            test.toolkit = "ambertools"
-
-        test.toolkit = toolkit_name
-        prov = test.provenance()
-        assert toolkit_name in prov
-        assert "openff-toolkit" in prov
-
-    else:
-        pytest.skip(f"Toolkit {toolkit_name} not avilable.")
+    prov = test.provenance(GLOBAL_TOOLKIT_REGISTRY)
+    for tk in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits:
+        if tk.__class__.__name__ != "BuiltInToolkitWrapper":
+            assert prov[tk.__class__.__name__] == tk.toolkit_version
 
 
-@pytest.mark.parametrize(
-    "toolkit",
-    [
-        pytest.param(("openeye", OpenEyeToolkitWrapper), id="openeye"),
-        pytest.param(("rdkit", RDKitToolkitWrapper), id="rdkit"),
-    ],
-)
-def test_standardconformer_generator_validators(toolkit):
+def test_standardconformer_generator_validators():
     """
     Test the standard conformer generator which calls the OFFTK.
     """
 
-    toolkit_name, toolkit_class = toolkit
-    if toolkit_class.is_available():
+    conf_gen = workflow_components.StandardConformerGenerator()
 
-        conf_gen = workflow_components.StandardConformerGenerator()
+    # make sure we are casting to ints
+    conf_gen.max_conformers = 1.02
+    assert conf_gen.max_conformers == 1
 
-        # make sure we are casting to ints
-        conf_gen.max_conformers = 1.02
-        assert conf_gen.max_conformers == 1
+    conf_gen.clear_existing = "no"
+    assert conf_gen.clear_existing is False
 
-        # test the toolkit validator
-        with pytest.raises(ValueError):
-            conf_gen.toolkit = "ambertools"
-        conf_gen.toolkit = toolkit_name
-        assert toolkit_name in conf_gen.provenance()
-
-        conf_gen.clear_existing = "no"
-        assert conf_gen.clear_existing is False
-
-        assert "openff-toolkit" in conf_gen.provenance()
-
-    else:
-        pytest.skip(f"Toolkit {toolkit} not available.")
+    assert "openff-toolkit" in conf_gen.provenance(GLOBAL_TOOLKIT_REGISTRY)
 
 
 def test_element_filter_validators():
@@ -275,7 +246,7 @@ def test_element_filter_validators():
 
     assert elem_filter.allowed_elements == [1, 2, 3]
 
-    assert "openmm_elements" in elem_filter.provenance()
+    assert "openmm_elements" in elem_filter.provenance(GLOBAL_TOOLKIT_REGISTRY)
 
 
 def test_weight_filter_validator():
@@ -287,13 +258,17 @@ def test_weight_filter_validator():
     weight.minimum_weight = 0.0
     assert weight.minimum_weight == 0
 
-    assert "openmm_units" in weight.provenance()
-    assert "openff-toolkit" in weight.provenance()
+    assert "openff-toolkit" in weight.provenance(GLOBAL_TOOLKIT_REGISTRY)
 
 
-def test_weight_filter_apply():
+@pytest.mark.parametrize("toolkits", [
+    pytest.param(ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper()]), id="rdkit"),
+    pytest.param(ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper()]), id="openeye")
+])
+def test_weight_filter_apply(toolkits):
     """
-    Make sure the weight filter returns molecules within the limits.
+    Make sure the weight filter returns molecules within the limits. As the backend function choice is handled by qcsubmit
+    we should test both options.
     """
 
     weight = workflow_components.MolecularWeightFilter()
@@ -302,9 +277,19 @@ def test_weight_filter_apply():
 
     molecules = get_tautomers()
 
-    result = weight.apply(molecules, processors=1)
+    result = weight.apply(molecules, processors=1, toolkit_registry=toolkits)
     assert result.n_molecules == 14
     assert result.n_filtered == 36
+
+
+def test_weight_filter_apply_no_toolkit():
+    """
+    Make sure an error is raised when we try to filter by weight but have no toolkit to do it.
+    """
+    with pytest.raises(ModuleNotFoundError):
+        weight = workflow_components.MolecularWeightFilter()
+        molecules = get_tautomers()
+        _ = weight.apply(molecules=molecules, toolkit_registry=ToolkitRegistry(), processors=1)
 
 
 @pytest.mark.parametrize(
@@ -351,7 +336,7 @@ def test_rmsd_filter():
     # make a lot of conformers for the molecule
     mol.generate_conformers(n_conformers=1000, rms_cutoff=0.05 * unit.angstrom, toolkit_registry=RDKitToolkitWrapper())
     ref_mol = copy.deepcopy(mol)
-    result = rmsd_filter.apply([mol, ], processors=1)
+    result = rmsd_filter.apply([mol, ], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     # now make sure the number of conformers is different
     assert result.molecules[0].n_conformers != ref_mol.n_conformers
 
@@ -362,49 +347,35 @@ def test_rmsd_filter_no_conformers():
     """
     rmsd_filter = workflow_components.RMSDCutoffConformerFilter(cutoff=1)
     mol = Molecule.from_smiles("CCCC")
-    result = rmsd_filter.apply([mol, ], processors=1)
+    result = rmsd_filter.apply([mol, ], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     # now make sure the number of conformers is different
     assert result.n_molecules == 0
     assert result.n_filtered == 1
 
 
-@pytest.mark.parametrize(
-    "toolkit",
-    [
-        pytest.param(("openeye", OpenEyeToolkitWrapper), id="openeye"),
-        pytest.param(("rdkit", RDKitToolkitWrapper), id="rdkit"),
-    ],
-)
-def test_conformer_apply(toolkit):
+def test_conformer_apply():
     """
     Test applying the standard conformer generator to a workflow.
     """
 
-    toolkit_name, toolkit_class = toolkit
-    if toolkit_class.is_available():
+    conf_gen = workflow_components.StandardConformerGenerator()
+    conf_gen.max_conformers = 1
+    conf_gen.clear_existing = True
 
-        conf_gen = workflow_components.StandardConformerGenerator()
-        conf_gen.toolkit = toolkit_name
-        conf_gen.max_conformers = 1
-        conf_gen.clear_existing = True
+    mols = get_stereoisomers()
+    # remove duplicates from the set
+    molecule_container = get_container(mols)
 
-        mols = get_stereoisomers()
-        # remove duplicates from the set
-        molecule_container = get_container(mols)
+    result = conf_gen.apply(molecule_container.molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
-        result = conf_gen.apply(molecule_container.molecules, processors=1)
+    assert result.component_name == conf_gen.type
+    assert result.component_description == conf_gen.dict()
+    # make sure each molecule has a conformer that passed
+    for molecule in result.molecules:
+        assert molecule.n_conformers == 1, print(molecule.conformers)
 
-        assert result.component_name == conf_gen.type
-        assert result.component_description == conf_gen.dict()
-        # make sure each molecule has a conformer that passed
-        for molecule in result.molecules:
-            assert molecule.n_conformers == 1, print(molecule.conformers)
-
-        for molecule in result.filtered:
-            assert molecule.n_conformers == 0
-
-    else:
-        pytest.skip(f"Toolkit {toolkit_name} not available.")
+    for molecule in result.filtered:
+        assert molecule.n_conformers == 0
 
 
 def test_elementfilter_apply():
@@ -417,7 +388,7 @@ def test_elementfilter_apply():
 
     mols = get_tautomers()
 
-    result = elem_filter.apply(mols, processors=1)
+    result = elem_filter.apply(mols, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert result.component_name == elem_filter.type
     assert result.component_description == elem_filter.dict()
@@ -431,116 +402,70 @@ def test_elementfilter_apply():
         assert sorted(elements) != sorted(elem_filter.allowed_elements)
 
 
-@pytest.mark.parametrize(
-    "toolkit",
-    [
-        pytest.param(("openeye", OpenEyeToolkitWrapper), id="openeye"),
-        pytest.param(("rdkit", RDKitToolkitWrapper), id="rdkit"),
-    ],
-)
-def test_enumerating_stereoisomers_validator(toolkit):
+def test_enumerating_stereoisomers_validator():
     """
     Test the validators in enumerating stereoisomers.
     """
+    enumerate_stereo = workflow_components.EnumerateStereoisomers()
 
-    toolkit_name, toolkit_class = toolkit
-    if toolkit_class.is_available():
+    enumerate_stereo.undefined_only = "y"
+    assert enumerate_stereo.undefined_only is True
 
-        enumerate_stereo = workflow_components.EnumerateStereoisomers()
-        with pytest.raises(ValueError):
-            enumerate_stereo.toolkit = "ambertools"
-
-        enumerate_stereo.toolkit = toolkit_name
-        assert toolkit_name in enumerate_stereo.provenance()
-
-        enumerate_stereo.undefined_only = "y"
-        assert enumerate_stereo.undefined_only is True
-
-        enumerate_stereo.max_isomers = 1.1
-        assert enumerate_stereo.max_isomers == 1
-
-    else:
-        pytest.skip(f"Toolkit {toolkit_name} is not available.")
+    enumerate_stereo.max_isomers = 1.1
+    assert enumerate_stereo.max_isomers == 1
 
 
-@pytest.mark.parametrize(
-    "toolkit",
-    [
-        pytest.param(("openeye", OpenEyeToolkitWrapper), id="openeye"),
-        pytest.param(("rdkit", RDKitToolkitWrapper), id="rdkit"),
-    ],
-)
-def test_enumerating_stereoisomers_apply(toolkit):
+def test_enumerating_stereoisomers_apply():
     """
     Test the stereoisomer enumeration.
     """
 
-    toolkit_name, toolkit_class = toolkit
-    if toolkit_class.is_available():
+    enumerate_stereo = workflow_components.EnumerateStereoisomers()
+    # set the options
+    enumerate_stereo.undefined_only = True
+    enumerate_stereo.rationalise = True
 
-        enumerate_stereo = workflow_components.EnumerateStereoisomers()
-        # set the options
-        enumerate_stereo.toolkit = toolkit_name
-        enumerate_stereo.undefined_only = True
-        enumerate_stereo.rationalise = True
+    mols = get_stereoisomers()
 
-        mols = get_stereoisomers()
+    result = enumerate_stereo.apply(mols, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
+    for mol in mols:
+        assert mol in result.molecules
 
-        result = enumerate_stereo.apply(mols, processors=1)
-        for mol in mols:
-            assert mol in result.molecules
-
-        # make sure no molecules have undefined stereo
-        for molecule in result.molecules:
-            assert Molecule.from_smiles(molecule.to_smiles(), toolkit_registry=RDKitToolkitWrapper()) == molecule
-            assert molecule.n_conformers >= 1
-
-    else:
-        pytest.skip(f"Toolkit {toolkit_name} is not available.")
+    # make sure no molecules have undefined stereo
+    for molecule in result.molecules:
+        assert Molecule.from_smiles(molecule.to_smiles(), toolkit_registry=RDKitToolkitWrapper()) == molecule
+        assert molecule.n_conformers >= 1
 
 
-@pytest.mark.parametrize(
-    "toolkit",
-    [
-        pytest.param(("openeye", OpenEyeToolkitWrapper), id="openeye"),
-        pytest.param(("rdkit", RDKitToolkitWrapper), id="rdkit"),
-    ],
-)
-def test_enumerating_stereoisomers_poor_input(toolkit):
+def test_enumerating_stereoisomers_poor_input():
     """
     Test stereoisomer enumeration with an impossible stereochemistry.
     """
 
-    toolkit_name, toolkit_class = toolkit
-    if toolkit_class.is_available():
-        molecule = Molecule.from_smiles("C=CCn1c([C@@H]2C[C@@H]3CC[C@@H]2O3)nnc1N1CCN(c2ccccc2)CC1")
-        enumerate_stereo = workflow_components.EnumerateStereoisomers()
-        # the molecule should fail conformer generation
-        enumerate_stereo.toolkit = toolkit_name
-        enumerate_stereo.undefined_only = True
-        enumerate_stereo.rationalise = True
+    molecule = Molecule.from_smiles("C=CCn1c([C@@H]2C[C@@H]3CC[C@@H]2O3)nnc1N1CCN(c2ccccc2)CC1")
+    enumerate_stereo = workflow_components.EnumerateStereoisomers()
+    # the molecule should fail conformer generation
+    enumerate_stereo.undefined_only = True
+    enumerate_stereo.rationalise = True
 
-        result = enumerate_stereo.apply(molecules=[molecule, ], processors=1)
-        assert result.n_molecules == 0
-        assert result.n_filtered == 1
+    result = enumerate_stereo.apply(molecules=[molecule, ], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
+    assert result.n_molecules == 0
+    assert result.n_filtered == 1
 
-        # now turn of rationalise
-        enumerate_stereo.rationalise = False
-        result = enumerate_stereo.apply([molecule, ], processors=1)
-        assert molecule in result.molecules
-        assert result.n_molecules == 1
+    # now turn of rationalise
+    enumerate_stereo.rationalise = False
+    result = enumerate_stereo.apply([molecule, ], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
+    assert molecule in result.molecules
+    assert result.n_molecules == 1
 
-        # now enumerate all stereo and rationalise
-        enumerate_stereo.rationalise = True
-        enumerate_stereo.undefined_only = False
-        # make sure the input is missing and new isomers are found
+    # now enumerate all stereo and rationalise
+    enumerate_stereo.rationalise = True
+    enumerate_stereo.undefined_only = False
+    # make sure the input is missing and new isomers are found
 
-        result = enumerate_stereo.apply([molecule, ], processors=1)
-        assert molecule not in result.molecules
-        assert molecule in result.filtered
-
-    else:
-        pytest.skip(f"Toolkit {toolkit_name} is not available.")
+    result = enumerate_stereo.apply([molecule, ], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
+    assert molecule not in result.molecules
+    assert molecule in result.filtered
 
 
 @pytest.mark.parametrize("data", [
@@ -556,68 +481,32 @@ def test_check_missing_stereo(data):
     assert result is check_missing_stereo(molecule=molecule)
 
 
-@pytest.mark.parametrize(
-    "toolkit",
-    [
-        pytest.param(("openeye", OpenEyeToolkitWrapper), id="openeye"),
-        pytest.param(("rdkit", RDKitToolkitWrapper), id="rdkit"),
-    ],
-)
-def test_enumerating_tautomers_apply(toolkit):
+def test_enumerating_tautomers_apply():
     """
     Test enumerating tautomers and make sue the input molecule is also returned.
     """
+    enumerate_tauts = workflow_components.EnumerateTautomers()
+    enumerate_tauts.max_tautomers = 2
 
-    toolkit_name, toolkit_class = toolkit
-    if toolkit_class.is_available():
+    mols = get_tautomers()
 
-        enumerate_tauts = workflow_components.EnumerateTautomers()
-        enumerate_tauts.toolkit = toolkit_name
-        enumerate_tauts.max_tautomers = 2
+    result = enumerate_tauts.apply(mols, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
-        mols = get_tautomers()
+    # check the input molecule is present
+    for mol in mols:
+        assert mol in result.molecules
 
-        result = enumerate_tauts.apply(mols, processors=1)
-
-        # check the input molecule is present
-        for mol in mols:
-            assert mol in result.molecules
-
-        assert result.n_molecules > len(mols)
-
-    else:
-        pytest.skip(f"Toolkit {toolkit_name} is not available.")
+    assert result.n_molecules > len(mols)
 
 
-@pytest.mark.parametrize(
-    "toolkit",
-    [
-        pytest.param(("openeye", OpenEyeToolkitWrapper), id="openeye"),
-        pytest.param(("rdkit", RDKitToolkitWrapper), id="rdkit"),
-    ],
-)
-def test_enumerating_tautomers_validator(toolkit):
+def test_enumerating_tautomers_validator():
     """
     Test the validators in enumerating tautomers.
     """
+    enumerate_tautomers = workflow_components.EnumerateTautomers()
 
-    toolkit_name, toolkit_class = toolkit
-
-    if toolkit_class.is_available():
-
-        enumerate_tautomers = workflow_components.EnumerateTautomers()
-
-        with pytest.raises(ValueError):
-            enumerate_tautomers.toolkit = "ambertools"
-
-        enumerate_tautomers.toolkit = toolkit_name
-        enumerate_tautomers.max_tautomers = 1.1
-        assert enumerate_tautomers.max_tautomers == 1
-
-        assert toolkit_name in enumerate_tautomers.provenance()
-
-    else:
-        pytest.skip(f"Toolkit {toolkit_name} not available.")
+    enumerate_tautomers.max_tautomers = 1.1
+    assert enumerate_tautomers.max_tautomers == 1
 
 
 def test_enumerating_protomers_apply():
@@ -628,12 +517,8 @@ def test_enumerating_protomers_apply():
     enumerate_protomers = workflow_components.EnumerateProtomers(max_states=2)
     assert enumerate_protomers.is_available()
 
-    with pytest.raises(ValueError):
-        # make sure rdkit is not allowed here
-        enumerate_protomers.toolkit = "rdkit"
-
     mol = Molecule.from_smiles('Oc2ccc(c1ccncc1)cc2')
-    result = enumerate_protomers.apply([mol, ], processors=1)
+    result = enumerate_protomers.apply([mol, ], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert mol in result.molecules
     # this means that the parent molecule was included
@@ -651,7 +536,7 @@ def test_coverage_filter_remove():
     # we have to remove duplicated records
     # remove duplicates from the set
     molecule_container = get_container(mols)
-    result = coverage_filter.apply(molecule_container.molecules, processors=1)
+    result = coverage_filter.apply(molecule_container.molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     forcefield = ForceField("openff_unconstrained-1.0.0.offxml")
     # now see if any molecules do not have b83
@@ -675,7 +560,7 @@ def test_coverage_filter_allowed():
     # we have to remove duplicated records
     # remove duplicates from the set
     molecule_container = get_container(mols)
-    result = coverage_filter.apply(molecule_container.molecules, processors=1)
+    result = coverage_filter.apply(molecule_container.molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     forcefield = ForceField("openff_unconstrained-1.0.0.offxml")
     # now see if any molecules do not have b83
@@ -706,7 +591,7 @@ def test_coverage_allowed_no_match():
     # we have to remove duplicated records
     # remove duplicates from the set
     molecule_container = get_container(mols)
-    result = coverage_filter.apply(molecule_container.molecules, processors=1)
+    result = coverage_filter.apply(molecule_container.molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     # make sure all molecules have been removed as none have the made up id
     assert result.n_molecules == 0
@@ -729,12 +614,12 @@ def test_wbo_fragmentation_apply():
     assert fragmenter.is_available()
     # check that a molecule with no rotatable bonds fails if we dont want the parent back
     benzene = Molecule.from_file(get_data("benzene.sdf"), "sdf")
-    result = fragmenter.apply([benzene, ], processors=1)
+    result = fragmenter.apply([benzene, ], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     assert result.n_molecules == 0
 
     # now try a molecule which should give fragments
     diphenhydramine = Molecule.from_smiles("O(CCN(C)C)C(c1ccccc1)c2ccccc2")
-    result = fragmenter.apply([diphenhydramine, ], processors=1)
+    result = fragmenter.apply([diphenhydramine, ], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     assert result.n_molecules == 4
     for molecule in result.molecules:
         assert "dihedrals" in molecule.properties
@@ -747,7 +632,7 @@ def test_pfizer_fragmentation_apply():
     assert fragmenter.is_available()
     # now try a molecule which should give fragments
     diphenhydramine = Molecule.from_smiles("O(CCN(C)C)C(c1ccccc1)c2ccccc2")
-    result = fragmenter.apply([diphenhydramine, ], processors=1)
+    result = fragmenter.apply([diphenhydramine, ], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     assert result.n_molecules == 4
     for molecule in result.molecules:
         assert "dihedrals" in molecule.properties
@@ -765,7 +650,7 @@ def test_rotor_filter_maximum():
 
     # we have to remove duplicated records
     molecule_container = get_container(mols)
-    result = rotor_filter.apply(molecule_container.molecules, processors=1)
+    result = rotor_filter.apply(molecule_container.molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     for molecule in result.molecules:
         assert len(molecule.find_rotatable_bonds()) <= rotor_filter.maximum_rotors
 
@@ -781,7 +666,7 @@ def test_rotor_filter_minimum():
 
     mols = get_tautomers()
     mol_container = get_container(mols)
-    result = rotor_filter.apply(mol_container.molecules, processors=1)
+    result = rotor_filter.apply(mol_container.molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     for molecule in result.molecules:
         assert len(molecule.find_rotatable_bonds()) >= rotor_filter.minimum_rotors
     for molecule in result.filtered:
@@ -798,10 +683,10 @@ def test_rotor_filter_validation():
     rotor_filter.minimum_rotors = 4
     mols = get_tautomers()
     mol_container = get_container(mols)
-    rotor_filter.apply(mol_container.molecules, processors=1)
+    rotor_filter.apply(mol_container.molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     rotor_filter.minimum_rotors = 5
     with pytest.raises(ValueError):
-        rotor_filter.apply(mol_container.molecules, processors=1)
+        rotor_filter.apply(mol_container.molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
 
 def test_rotor_filter_fail():
@@ -815,7 +700,7 @@ def test_rotor_filter_fail():
     mols = get_tautomers()
 
     molecule_container = get_container(mols)
-    result = rotor_filter.apply(molecule_container.molecules, processors=1)
+    result = rotor_filter.apply(molecule_container.molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     for molecule in result.molecules:
         assert len(molecule.find_rotatable_bonds()) <= rotor_filter.maximum_rotors
     for molecule in result.filtered:
@@ -863,7 +748,7 @@ def test_smarts_filter_allowed():
 
     molecules = get_tautomers()
 
-    result = filter.apply(molecules, processors=1)
+    result = filter.apply(molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert result.component_name == filter.type
     assert result.component_description == filter.dict()
@@ -887,7 +772,7 @@ def test_smarts_filter_allowed_no_match():
 
     molecules = get_tautomers()
 
-    result = filter.apply(molecules, processors=1)
+    result = filter.apply(molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     assert result.n_molecules == 0
 
 
@@ -901,7 +786,7 @@ def test_smarts_filter_remove():
 
     molecules = get_tautomers()
 
-    result = filter.apply(molecules, processors=1)
+    result = filter.apply(molecules, processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert result.component_name == filter.type
     assert result.component_description == filter.dict()
@@ -932,7 +817,7 @@ def test_scan_filter_no_torsions():
 
     filter = workflow_components.ScanFilter(scans_to_include=["[*:1]~[*:2]-[CH3:3]-[H:4]"])
 
-    result = filter.apply(molecules=[molecule], processors=1)
+    result = filter.apply(molecules=[molecule], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     assert result.n_molecules == 0
 
 
@@ -951,7 +836,7 @@ def test_scan_filter_include():
     # only keep the C-C scan
     filter = workflow_components.ScanFilter(scans_to_include=["[#1:1]~[#6:2]-[#6:3]-[#1:4]"])
 
-    result = filter.apply(molecules=[ethanol], processors=1)
+    result = filter.apply(molecules=[ethanol], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert result.n_molecules == 1
     assert (0, 1) in ethanol.properties["dihedrals"].torsions
@@ -972,7 +857,7 @@ def test_scan_filter_exclude():
     # only keep the C-C scan
     filter = workflow_components.ScanFilter(scans_to_exclude=["[#1:1]~[#6:2]-[#6:3]-[#1:4]"])
 
-    result = filter.apply(molecules=[ethanol], processors=1)
+    result = filter.apply(molecules=[ethanol], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert result.n_molecules == 1
     assert (1, 2) in ethanol.properties["dihedrals"].torsions
@@ -987,7 +872,7 @@ def test_scan_enumerator_no_scans():
     scan_tagger = workflow_components.ScanEnumerator()
     scan_tagger.add_torsion_scan(smarts="[*:1]~[#8:1]-[#6:3]~[*:4]", scan_rage=(-40, 40), scan_increment=15)
 
-    result = scan_tagger.apply([mol], processors=1)
+    result = scan_tagger.apply([mol], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert result.n_molecules == 0
     assert result.n_filtered == 1
@@ -1002,7 +887,7 @@ def test_scan_enumerator_1d():
     scan_tagger = workflow_components.ScanEnumerator()
     scan_tagger.add_torsion_scan(smarts="[*:1]~[#6:2]-[#6:3]~[*:4]", scan_rage=(-60, 60), scan_increment=20)
 
-    result = scan_tagger.apply([mol], processors=1)
+    result = scan_tagger.apply([mol], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert result.n_molecules == 1
     indexer = mol.properties["dihedrals"]
@@ -1019,7 +904,7 @@ def test_scan_enumerator_unique():
     scan_tagger = workflow_components.ScanEnumerator()
     scan_tagger.add_torsion_scan(smarts="[*:1]~[#6:2]-[#6:3]~[*:4]")
 
-    result = scan_tagger.apply(molecules=[mol], processors=1)
+    result = scan_tagger.apply(molecules=[mol], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert result.n_molecules == 1
     indexer = mol.properties["dihedrals"]
@@ -1039,7 +924,7 @@ def test_scan_enumerator_2d():
                                    scan_range2=(-60, 60),
                                    scan_increments=[15, 4])
 
-    result = scan_tagger.apply([mol], processors=1)
+    result = scan_tagger.apply([mol], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     assert result.n_molecules == 1
     indexer = mol.properties["dihedrals"]
     assert indexer.n_double_torsions == 1
@@ -1058,7 +943,7 @@ def test_improper_enumerator():
     # even though there is more than one improper make sure we only get one scan back
     scan_tagger.add_improper_torsion(smarts="[#6:1](-[#1:2])(:[#6:3]):[#6:4]", central_smarts="[#6:1]", scan_range=(-40, 40), scan_increment=4)
 
-    result = scan_tagger.apply([mol], processors=1)
+    result = scan_tagger.apply([mol], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
 
     assert result.n_molecules == 1
     indexer = mol.properties["dihedrals"]
@@ -1084,11 +969,11 @@ def test_formal_charge_filter():
 
     # filter out the molecule
     charge_filter = workflow_components.ChargeFilter(charges_to_exclude=[-1, 0])
-    result = charge_filter.apply([molecule], processors=1)
+    result = charge_filter.apply([molecule], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     assert result.n_molecules == 0
     assert result.n_filtered == 1
 
     # now allow it through
     charge_filter = workflow_components.ChargeFilter(charges_to_include=[-1])
-    result = charge_filter.apply([molecule], processors=1)
+    result = charge_filter.apply([molecule], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
     assert result.n_molecules == 1

--- a/openff/qcsubmit/workflow_components/__init__.py
+++ b/openff/qcsubmit/workflow_components/__init__.py
@@ -6,7 +6,6 @@ from openff.qcsubmit.workflow_components.base import (
     register_component,
 )
 from openff.qcsubmit.workflow_components.base_component import (
-    BasicSettings,
     CustomWorkflowComponent,
     ToolkitValidator,
 )
@@ -47,7 +46,6 @@ __all__ = [
     register_component,
     list_components,
     get_component,
-    BasicSettings,
     CustomWorkflowComponent,
     ToolkitValidator,
     StandardConformerGenerator,

--- a/openff/qcsubmit/workflow_components/conformer_generation.py
+++ b/openff/qcsubmit/workflow_components/conformer_generation.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 import simtk.unit as unit
 from openff.toolkit.topology import Molecule
+from openff.toolkit.utils import ToolkitRegistry
 from pydantic import Field
 from typing_extensions import Literal
 
@@ -52,12 +53,15 @@ class StandardConformerGenerator(ToolkitValidator, CustomWorkflowComponent):
         else:
             self._cache["cutoff"] = None
 
-    def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+    def _apply(
+        self, molecules: List[Molecule], toolkit_registry: ToolkitRegistry
+    ) -> ComponentResult:
         """
         Generate conformers for the molecules using the selected toolkit backend.
 
         Args:
             molecules: The list of molecules the component should be applied on.
+            toolkit_registry: The openff.toolkit.utils.ToolkitRegistry that declares the available toolkits.
 
         Returns:
             An instance of the [ComponentResult][qcsubmit.datasets.ComponentResult]
@@ -66,9 +70,7 @@ class StandardConformerGenerator(ToolkitValidator, CustomWorkflowComponent):
         """
 
         # create the toolkit
-        toolkit = self._toolkits[self.toolkit]()
-
-        result = self._create_result()
+        result = self._create_result(toolkit_registry=toolkit_registry)
 
         rms_cutoff = self._cache["cutoff"]
 
@@ -79,7 +81,7 @@ class StandardConformerGenerator(ToolkitValidator, CustomWorkflowComponent):
                     n_conformers=self.max_conformers,
                     clear_existing=self.clear_existing,
                     rms_cutoff=rms_cutoff,
-                    toolkit_registry=toolkit,
+                    toolkit_registry=toolkit_registry,
                 )
 
             # need to catch more specific exceptions here.

--- a/openff/qcsubmit/workflow_components/filters.py
+++ b/openff/qcsubmit/workflow_components/filters.py
@@ -5,6 +5,11 @@ from typing import Dict, List, Optional, Set, Union
 
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.toolkit.utils import (
+    OpenEyeToolkitWrapper,
+    RDKitToolkitWrapper,
+    ToolkitRegistry,
+)
 from pydantic import Field, root_validator, validator
 from rdkit.Chem.rdMolAlign import AlignMol
 from simtk import unit
@@ -13,13 +18,13 @@ from typing_extensions import Literal
 from openff.qcsubmit.common_structures import ComponentProperties
 from openff.qcsubmit.validators import check_allowed_elements, check_environments
 from openff.qcsubmit.workflow_components.base_component import (
-    BasicSettings,
     CustomWorkflowComponent,
+    ToolkitValidator,
 )
 from openff.qcsubmit.workflow_components.utils import ComponentResult
 
 
-class MolecularWeightFilter(BasicSettings, CustomWorkflowComponent):
+class MolecularWeightFilter(ToolkitValidator, CustomWorkflowComponent):
     """
     Filters molecules based on the minimum and maximum allowed molecular weights.
     """
@@ -46,25 +51,39 @@ class MolecularWeightFilter(BasicSettings, CustomWorkflowComponent):
     def properties(cls) -> ComponentProperties:
         return ComponentProperties(process_parallel=True, produces_duplicates=False)
 
-    def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+    def _apply(
+        self, molecules: List[Molecule], toolkit_registry: ToolkitRegistry
+    ) -> ComponentResult:
         """
         The common entry point of all workflow components which applies the workflow component to the given list of
         molecules.
 
         Parameters:
             molecules: The list of molecules the component should be applied on.
+            toolkit_registry: The openff.toolkit.utils.ToolkitRegistry which declares the available toolkits.
 
         Returns:
             A [ComponentResult][qcsubmit.datasets.ComponentResult] instance containing information about the molecules
             that passed and were filtered by the component and details about the component which generated the result.
         """
 
-        from rdkit.Chem import Descriptors
-
-        result = self._create_result()
+        result = self._create_result(toolkit_registry=toolkit_registry)
+        # work out the weight function
+        for toolkit in toolkit_registry.registered_toolkits:
+            if isinstance(toolkit, OpenEyeToolkitWrapper):
+                weight_func = self._get_openeye_weight
+                break
+            elif isinstance(toolkit, RDKitToolkitWrapper):
+                weight_func = self._get_rdkit_weight
+                break
+        else:
+            raise ModuleNotFoundError(
+                "Either openeye or rdkit must be registered with the toolkit registry to use"
+                "the weight filter."
+            )
 
         for molecule in molecules:
-            total_weight = Descriptors.ExactMolWt(molecule.to_rdkit())
+            total_weight = weight_func(molecule)
 
             if self.minimum_weight < total_weight < self.maximum_weight:
                 result.add_molecule(molecule)
@@ -73,26 +92,24 @@ class MolecularWeightFilter(BasicSettings, CustomWorkflowComponent):
 
         return result
 
-    def provenance(self) -> Dict:
+    def _get_rdkit_weight(self, molecule: Molecule) -> float:
         """
-        Generate version information for all of the software used during the running of this component.
-
-        Returns:
-            A dictionary of all of the software used in the component along wither their version numbers.
-
-        Important:
-            The simtk unit module has no version information so the version of OpenMM is given instead.
+        Calculate the weight of the molecule using rdkit.
         """
+        from rdkit.Chem import Descriptors
 
-        from simtk import openmm
+        return Descriptors.ExactMolWt(molecule.to_rdkit())
 
-        provenance = super().provenance()
-        provenance["openmm_units"] = openmm.__version__
+    def _get_openeye_weight(self, molecule: Molecule) -> float:
+        """
+        Calculate the weight of the molecule using openeye.
+        """
+        from openeye import oechem
 
-        return provenance
+        return oechem.OECalculateMolecularWeight(molecule.to_openeye())
 
 
-class ElementFilter(BasicSettings, CustomWorkflowComponent):
+class ElementFilter(ToolkitValidator, CustomWorkflowComponent):
     """
     Filter the molecules based on a list of allowed elements.
 
@@ -155,20 +172,23 @@ class ElementFilter(BasicSettings, CustomWorkflowComponent):
             for ele in self.allowed_elements
         ]
 
-    def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+    def _apply(
+        self, molecules: List[Molecule], toolkit_registry: ToolkitRegistry
+    ) -> ComponentResult:
         """
         The common entry point of all workflow components which applies the workflow component to the given list of
         molecules.
 
         Parameters:
             molecules: The list of molecules the component should be applied on.
+            toolkit_registry: The openff.toolkit.utils.ToolkitRegistry which declares the avilable toolkits.
 
         Returns:
             A [ComponentResult][qcsubmit.datasets.ComponentResult] instance containing information about the molecules
             that passed and were filtered by the component and details about the component which generated the result.
         """
 
-        result = self._create_result()
+        result = self._create_result(toolkit_registry=toolkit_registry)
 
         # First lets convert the allowed_elements list to ints as this is what is stored in the atom object
         _allowed_elements = self._cache["elements"]
@@ -184,7 +204,7 @@ class ElementFilter(BasicSettings, CustomWorkflowComponent):
 
         return result
 
-    def provenance(self) -> Dict:
+    def provenance(self, toolkit_registry: ToolkitRegistry) -> Dict:
         """
         Generate version information for all of the software used during the running of this component.
 
@@ -197,13 +217,13 @@ class ElementFilter(BasicSettings, CustomWorkflowComponent):
 
         from simtk import openmm
 
-        provenance = super().provenance()
+        provenance = super().provenance(toolkit_registry=toolkit_registry)
         provenance["openmm_elements"] = openmm.__version__
 
         return provenance
 
 
-class CoverageFilter(BasicSettings, CustomWorkflowComponent):
+class CoverageFilter(ToolkitValidator, CustomWorkflowComponent):
     """
     Filters molecules based on the requested force field parameter ids.
 
@@ -255,20 +275,23 @@ class CoverageFilter(BasicSettings, CustomWorkflowComponent):
 
         self._cache["forcefield"] = ForceField(self.forcefield)
 
-    def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+    def _apply(
+        self, molecules: List[Molecule], toolkit_registry: ToolkitRegistry
+    ) -> ComponentResult:
         """
         Apply the filter to the list of molecules to remove any molecules typed by an id that is not allowed, i.e. not
         included in the allowed list.
 
         Args:
             molecules: The list of molecules the component should be applied on.
+            toolkit_registry: The openff.toolkit.utils.ToolkitRegistry which declares the available toolkits.
 
         Returns:
             A [ComponentResult][qcsubmit.datasets.ComponentResult] instance containing information about the molecules
             that passed and were filtered by the component and details about the component which generated the result.
         """
 
-        result = self._create_result()
+        result = self._create_result(toolkit_registry=toolkit_registry)
 
         forcefield: ForceField = self._cache["forcefield"]
 
@@ -296,7 +319,7 @@ class CoverageFilter(BasicSettings, CustomWorkflowComponent):
 
         return result
 
-    def provenance(self) -> Dict:
+    def provenance(self, toolkit_registry: ToolkitRegistry) -> Dict:
         """
         Generate version information for all of the software used during the running of this component.
 
@@ -305,13 +328,13 @@ class CoverageFilter(BasicSettings, CustomWorkflowComponent):
         """
         import openforcefields
 
-        provenance = super().provenance()
+        provenance = super().provenance(toolkit_registry=toolkit_registry)
         provenance["openforcefields"] = openforcefields.__version__
 
         return provenance
 
 
-class RotorFilter(BasicSettings, CustomWorkflowComponent):
+class RotorFilter(ToolkitValidator, CustomWorkflowComponent):
     """
     Filters molecules based on the maximum and or minimum allowed number of rotatable bonds.
 
@@ -352,13 +375,16 @@ class RotorFilter(BasicSettings, CustomWorkflowComponent):
                     "The maximum number of rotors should >= the minimum to ensure some molecules pass."
                 )
 
-    def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+    def _apply(
+        self, molecules: List[Molecule], toolkit_registry: ToolkitRegistry
+    ) -> ComponentResult:
         """
         Apply the filter to the list of molecules to remove any molecules with more rotors then the maximum allowed
         number.
 
         Args:
             molecules: The list of molecules the component should be applied on.
+            toolkit_registry: The openff.toolkit.utils.ToolkitRegistry which declares the avilable toolkits.
 
         Returns:
             A [ComponentResult][qcsubmit.datasets.ComponentResult] instance containing information about the molecules
@@ -366,11 +392,13 @@ class RotorFilter(BasicSettings, CustomWorkflowComponent):
         """
 
         # create the return
-        result = self._create_result()
+        result = self._create_result(toolkit_registry=toolkit_registry)
 
         for molecule in molecules:
             # cache the rotatable bonds calc and only check fail conditions
-            rotatable_bonds = molecule.find_rotatable_bonds()
+            rotatable_bonds = molecule.find_rotatable_bonds(
+                toolkit_registry=toolkit_registry
+            )
             if self.maximum_rotors and len(rotatable_bonds) > self.maximum_rotors:
                 result.filter_molecule(molecule)
             elif self.minimum_rotors and len(rotatable_bonds) < self.minimum_rotors:
@@ -381,7 +409,7 @@ class RotorFilter(BasicSettings, CustomWorkflowComponent):
         return result
 
 
-class SmartsFilter(BasicSettings, CustomWorkflowComponent):
+class SmartsFilter(ToolkitValidator, CustomWorkflowComponent):
     """
     Filters molecules based on if they contain certain smarts substructures.
 
@@ -432,26 +460,31 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
 
         return values
 
-    def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+    def _apply(
+        self, molecules: List[Molecule], toolkit_registry: ToolkitRegistry
+    ) -> ComponentResult:
         """
         Apply the filter to the input list of molecules removing those that match the filtered set or do not contain an
         allowed substructure.
 
         Args:
             molecules: The list of molecules the component should be applied on.
+            toolkit_registry: The openff.toolkit.utils.ToolkitRegistry which declares the avilable toolkits.
 
         Returns:
             A [ComponentResult][qcsubmit.datasets.ComponentResult] instance containing information about the molecules
             that passed and were filtered by the component and details about the component which generated the result.
         """
 
-        result = self._create_result()
+        result = self._create_result(toolkit_registry=toolkit_registry)
 
         for molecule in molecules:
 
             if self.allowed_substructures is not None:
                 for substructure in self.allowed_substructures:
-                    if molecule.chemical_environment_matches(query=substructure):
+                    if molecule.chemical_environment_matches(
+                        query=substructure, toolkit_registry=toolkit_registry
+                    ):
                         result.add_molecule(molecule=molecule)
                         break
                 else:
@@ -460,7 +493,9 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
 
             elif self.filtered_substructures is not None:
                 for substructure in self.filtered_substructures:
-                    if molecule.chemical_environment_matches(query=substructure):
+                    if molecule.chemical_environment_matches(
+                        query=substructure, toolkit_registry=toolkit_registry
+                    ):
                         result.filter_molecule(molecule=molecule)
                         break
                 else:
@@ -470,7 +505,7 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
         return result
 
 
-class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
+class RMSDCutoffConformerFilter(ToolkitValidator, CustomWorkflowComponent):
     """
     Prunes conformers from a molecule that are less than a specified RMSD from
     all other conformers
@@ -537,7 +572,9 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
 
             molecule._conformers = confs.copy()
 
-    def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+    def _apply(
+        self, molecules: List[Molecule], toolkit_registry: ToolkitRegistry
+    ) -> ComponentResult:
         """
         Prunes conformers from a molecule that are less than a specified RMSD from
         all other conformers
@@ -550,7 +587,7 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
             that passed and were filtered by the component and details about the component which generated the result.
         """
 
-        result = self._create_result()
+        result = self._create_result(toolkit_registry=toolkit_registry)
 
         for molecule in molecules:
 
@@ -563,7 +600,7 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
         return result
 
 
-class ScanFilter(BasicSettings, CustomWorkflowComponent):
+class ScanFilter(ToolkitValidator, CustomWorkflowComponent):
     """
     A filter to remove/include molecules from the workflow who have scans targeting the specified SMARTS.
 
@@ -615,12 +652,14 @@ class ScanFilter(BasicSettings, CustomWorkflowComponent):
         assert scans_to_include is None or scans_to_exclude is None, message
         return values
 
-    def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+    def _apply(
+        self, molecules: List[Molecule], toolkit_registry: ToolkitRegistry
+    ) -> ComponentResult:
         """
         Keep or remove scans based on the list of torsions to include or remove.
         """
 
-        result = self._create_result()
+        result = self._create_result(toolkit_registry=toolkit_registry)
 
         target_environments = self.scans_to_exclude or self.scans_to_include
 
@@ -634,7 +673,9 @@ class ScanFilter(BasicSettings, CustomWorkflowComponent):
             all_matches = set()
             for env in target_environments:
                 # get all matches as a list of sorted central bonds as they are stored this way
-                matches = molecule.chemical_environment_matches(query=env)
+                matches = molecule.chemical_environment_matches(
+                    query=env, toolkit_registry=toolkit_registry
+                )
                 for match in matches:
                     match = match if len(match) == 2 else match[1:3]
                     all_matches.add(tuple(sorted(match)))
@@ -663,7 +704,7 @@ class ScanFilter(BasicSettings, CustomWorkflowComponent):
         return result
 
 
-class ChargeFilter(BasicSettings, CustomWorkflowComponent):
+class ChargeFilter(ToolkitValidator, CustomWorkflowComponent):
     """
     Filter molecules if their formal charge is not in the `charges_to_include` list or is in the `charges_to_exclude` list.
     """
@@ -705,12 +746,14 @@ class ChargeFilter(BasicSettings, CustomWorkflowComponent):
 
         return values
 
-    def _apply(self, molecules: List[Molecule]) -> ComponentResult:
+    def _apply(
+        self, molecules: List[Molecule], toolkit_registry: ToolkitRegistry
+    ) -> ComponentResult:
         """
         Filter molecules based on their net formal charge
         """
 
-        result = self._create_result()
+        result = self._create_result(toolkit_registry=toolkit_registry)
 
         for molecule in molecules:
             total_charge = molecule.total_charge.value_in_unit(unit.elementary_charge)


### PR DESCRIPTION
## Description
This PR allows the workflow components and the dataset factories to take a toolkit registry object that declares the available backend toolkits and their querying presence for functionality. If `None` is passed the default global toolkit registry will be used which contains all currently installed toolkits. This replaces the per-component toolkit argument. The provenance information now contains all toolkits in the passed toolkit registry. 

## Status
- [x] Ready to go