### PR TITLE
Filter by keywords when mapping to basic collection

### DIFF
--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -521,7 +521,12 @@ class OptimizationResultCollection(_BaseResultCollection):
 
         for record, molecule in records_and_molecules:
 
-            spec = (record.qc_spec.program, record.qc_spec.method, record.qc_spec.basis)
+            spec = (
+                record.qc_spec.program,
+                record.qc_spec.method,
+                record.qc_spec.basis,
+                record.qc_spec.keywords,
+            )
 
             final_molecule_ids[record.client.address][spec].append(
                 record.final_molecule
@@ -536,9 +541,12 @@ class OptimizationResultCollection(_BaseResultCollection):
 
             result_records = [
                 record
-                for (program, method, basis), molecules_ids in final_molecule_ids[
-                    client_address
-                ].items()
+                for (
+                    program,
+                    method,
+                    basis,
+                    keywords,
+                ), molecules_ids in final_molecule_ids[client_address].items()
                 for batch_ids in batched_indices(molecules_ids, client.query_limit)
                 for record in client.query_results(
                     molecule=batch_ids,
@@ -546,6 +554,7 @@ class OptimizationResultCollection(_BaseResultCollection):
                     program=program,
                     method=method,
                     basis=basis,
+                    keywords=keywords,
                 )
             ]
 


### PR DESCRIPTION
## Description

This PR aims to patch errors raised when mapping an optimizations collection to a basic collection caused by issues in the QCFractal server.

From slack:

I'm trying to pull some result records (gradient and hessian) from QCA but I'm getting a connection refused error:

```
from qcportal import FractalClient

client = FractalClient('https://api.qcarchive.molssi.org:443/')

results = client.query_results(
    program='psi4',
    molecule=[
        '12160621', '12162704', '12159790', '12168415',
        '12164932', '12154972', '12158785', '12176447',
        '12182844', '12170904', '12183903'
    ],
    driver=['gradient', 'hessian'],
    method='b3lyp-d3bj',
    basis='dzvp',
    status='COMPLETE'
)
```

> ../../../../../miniconda3/envs/descent/lib/python3.9/site-packages/qcportal/client.py:718: in query_results
>     response = self._automodel_request("result", "get", payload, full_return=True)
> ../../../../../miniconda3/envs/descent/lib/python3.9/site-packages/qcportal/client.py:274: in _automodel_request
>     r = self._request(rest, name, data=payload.serialize(self.encoding), timeout=timeout)
> ...
> Could not connect to server https://api.qcarchive.molssi.org:443/, please check the address and try again.

@bennybp response:

> ok I see. Has to do with the way the table is indexed. It will go a lot faster if you know the id of the keywords

## Status
- [X] Ready to go