### PR TITLE
Update OpenMM imports for 7.6 and backwards compatibility

### DIFF
--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -661,7 +661,11 @@ class _BaseDataset(abc.ABC, CommonBase):
         import warnings
 
         import basis_set_exchange as bse
-        from simtk.openmm.app import Element
+
+        try:
+            from openmm.app import Element
+        except ImportError:
+            from simtk.openmm.app import Element
 
         basis_report = {}
         for spec in self.qc_specifications.values():

--- a/openff/qcsubmit/datasets/entries.py
+++ b/openff/qcsubmit/datasets/entries.py
@@ -8,7 +8,11 @@ import numpy as np
 import openff.toolkit.topology as off
 import qcelemental as qcel
 from pydantic import Field, validator
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 
 from openff.qcsubmit.common_structures import (
     DatasetConfig,

--- a/openff/qcsubmit/results/caching.py
+++ b/openff/qcsubmit/results/caching.py
@@ -11,7 +11,11 @@ from qcportal import FractalClient
 from qcportal.models import Molecule as QCMolecule
 from qcportal.models import TorsionDriveRecord
 from qcportal.models.records import OptimizationRecord, RecordBase, ResultRecord
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 
 if TYPE_CHECKING:
     from openff.qcsubmit.results.results import (

--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -21,7 +21,11 @@ from qcportal.models.records import (
     RecordStatusEnum,
     ResultRecord,
 )
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 from typing_extensions import Literal
 
 from openff.qcsubmit.results.results import (
@@ -611,7 +615,10 @@ class ElementFilter(CMILESResultFilter):
         return not bool(mol_atoms.difference(self._allowed_atomic_numbers))
 
     def _apply(self, result_collection: "T") -> "T":
-        from simtk.openmm.app import Element
+        try:
+            from openmm.app import Element
+        except ImportError:
+            from simtk.openmm.app import Element
 
         self._allowed_atomic_numbers = {
             Element.getBySymbol(ele).atomic_number if isinstance(ele, str) else ele

--- a/openff/qcsubmit/tests/results/__init__.py
+++ b/openff/qcsubmit/tests/results/__init__.py
@@ -14,7 +14,11 @@ from qcportal.models import (
 )
 from qcportal.models.records import RecordStatusEnum
 from qcportal.models.torsiondrive import TDKeywords
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 
 from openff.qcsubmit.results import (
     BasicResult,

--- a/openff/qcsubmit/tests/results/conftest.py
+++ b/openff/qcsubmit/tests/results/conftest.py
@@ -1,7 +1,11 @@
 import numpy as np
 import pytest
 from openff.toolkit.topology import Molecule
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 
 from openff.qcsubmit.results import (
     BasicResultCollection,

--- a/openff/qcsubmit/tests/results/test_caching.py
+++ b/openff/qcsubmit/tests/results/test_caching.py
@@ -5,7 +5,11 @@ import pytest
 import requests_mock
 from openff.toolkit.topology import Molecule
 from qcportal.models import ObjectId, OptimizationRecord, ResultRecord
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 
 from openff.qcsubmit.results import BasicResult, OptimizationResult, TorsionDriveResult
 from openff.qcsubmit.results.caching import (

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from qcelemental.models import DriverEnum
 from qcportal.models import ObjectId, ResultRecord
 from qcportal.models.records import RecordStatusEnum
+
 try:
     from openmm import unit
 except ImportError:

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -7,7 +7,10 @@ from pydantic import ValidationError
 from qcelemental.models import DriverEnum
 from qcportal.models import ObjectId, ResultRecord
 from qcportal.models.records import RecordStatusEnum
-from simtk import unit
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 
 from openff.qcsubmit.results import (
     BasicResult,

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -22,7 +22,11 @@ from qcportal.models.common_models import (
 )
 from qcportal.models.records import RecordStatusEnum
 from qcportal.models.torsiondrive import TDKeywords
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 
 from openff.qcsubmit.common_structures import QCSpec
 from openff.qcsubmit.exceptions import RecordTypeError

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -9,7 +9,11 @@ import pytest
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from pydantic import ValidationError
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 
 from openff.qcsubmit.common_structures import MoleculeAttributes
 from openff.qcsubmit.constraints import Constraints, PositionConstraintSet

--- a/openff/qcsubmit/tests/test_workflow_components.py
+++ b/openff/qcsubmit/tests/test_workflow_components.py
@@ -329,7 +329,10 @@ def test_rmsd_filter():
     """
     import copy
 
-    from simtk import unit
+    try:
+        from openmm import unit
+    except ImportError:
+        from simtk import unit
 
     rmsd_filter = workflow_components.RMSDCutoffConformerFilter(cutoff=1)
     mol = Molecule.from_smiles("CCCC")

--- a/openff/qcsubmit/validators.py
+++ b/openff/qcsubmit/validators.py
@@ -275,7 +275,10 @@ def check_allowed_elements(element: Union[str, int]) -> Union[str, int]:
     Raises:
         ValueError: If the element number or symbol passed could not be converted into a valid element.
     """
-    from simtk.openmm.app import Element
+    try:
+        from openmm.app import Element
+    except ImportError:
+        from simtk.openmm.app import Element
 
     if isinstance(element, int):
         return element

--- a/openff/qcsubmit/workflow_components/filters.py
+++ b/openff/qcsubmit/workflow_components/filters.py
@@ -12,7 +12,11 @@ from openff.toolkit.utils import (
 )
 from pydantic import Field, root_validator, validator
 from rdkit.Chem.rdMolAlign import AlignMol
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 from typing_extensions import Literal
 
 from openff.qcsubmit.common_structures import ComponentProperties
@@ -165,7 +169,10 @@ class ElementFilter(ToolkitValidator, CustomWorkflowComponent):
 
     def _apply_init(self, result: ComponentResult) -> None:
 
-        from simtk.openmm.app import Element
+        try:
+            from openmm.app import Element
+        except ImportError:
+            from simtk.openmm.app import Element
 
         self._cache["elements"] = [
             Element.getBySymbol(ele).atomic_number if isinstance(ele, str) else ele
@@ -215,7 +222,10 @@ class ElementFilter(ToolkitValidator, CustomWorkflowComponent):
             The element class in OpenMM is used to match the elements so the OpenMM version is given.
         """
 
-        from simtk import openmm
+        try:
+            import openmm
+        except ImportError:
+            from simtk import openmm
 
         provenance = super().provenance(toolkit_registry=toolkit_registry)
         provenance["openmm_elements"] = openmm.__version__

--- a/openff/qcsubmit/workflow_components/utils.py
+++ b/openff/qcsubmit/workflow_components/utils.py
@@ -6,7 +6,11 @@ import numpy as np
 import openff.toolkit.topology as off
 import tqdm
 from pydantic import Field, validator
-from simtk import unit
+
+try:
+    from openmm import unit
+except ImportError:
+    from simtk import unit
 
 from openff.qcsubmit.common_structures import DatasetConfig, ResultsConfig
 from openff.qcsubmit.validators import check_environments


### PR DESCRIPTION
I noticed tests were failing due to the API breaks in OpenMM 7.6. I tried to update everything to work with the new version (avoiding deprecation warnings) but also be compatible with 7.5.x. I was unable to test everything locally but the major one in `ElementFilter` should be fixed.