### PR TITLE
Add minimum N conformers result filter

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -37,5 +37,6 @@ dependencies:
   # Optional
   - openmmforcefields >=0.9.0
   - openff-fragmenter
+  - openmm <7.6  # Needed until a new QCEngine release.
 #  - pip:
 #      - git+https://github.com/openforcefield/openff-fragmenter.git@master

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -41,5 +41,6 @@ dependencies:
   # Optional
   - openmmforcefields >=0.9.0
   - openff-fragmenter
+  - openmm <7.6  # Needed until a new QCEngine release.
 #  - pip:
 #      - git+https://github.com/openforcefield/openff-fragmenter.git@master

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -99,6 +99,7 @@ Filters
     UnperceivableStereoFilter
     LowestEnergyFilter
     ConformerRMSDFilter
+    MinimumConformersFilter
 
 Caching
 """""""

--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -422,6 +422,37 @@ class ConformerRMSDFilter(ResultRecordGroupFilter):
         ]
 
 
+class MinimumConformersFilter(ResultRecordGroupFilter):
+    """A filter that will only retain molecules that have at least a specified number
+    of conformers present in the result collection.
+
+    Notes:
+        * This filter will only be applied to basic and optimization datasets.
+          Torsion drive datasets / entries will be skipped.
+    """
+
+    min_conformers: int = Field(
+        2,
+        description="The minimum number of conformers that must be found in order to "
+        "retain a molecule and it's associated records.",
+    )
+
+    def _filter_function(
+        self,
+        entries: List[
+            Tuple["_BaseResult", Union[ResultRecord, OptimizationRecord], Molecule, str]
+        ],
+    ) -> List[Tuple["_BaseResult", str]]:
+
+        # Sanity check that all molecules look as we expect.
+        assert all(molecule.n_conformers == 1 for _, _, molecule, _ in entries)
+
+        if len(entries) < self.min_conformers:
+            return []
+
+        return [(entry, address) for entry, _, _, address in entries]
+
+
 class SMILESFilter(CMILESResultFilter):
     """A filter which will remove or retain records which were computed for molecules
     described by specific SMILES patterns.

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -31,7 +31,7 @@ from openff.qcsubmit.results.filters import (
     ResultRecordFilter,
     SMARTSFilter,
     SMILESFilter,
-    UnperceivableStereoFilter,
+    UnperceivableStereoFilter, MinimumConformersFilter,
 )
 from openff.qcsubmit.tests.results import mock_optimization_result_collection
 
@@ -302,6 +302,23 @@ def test_lowest_energy_filter(optimization_result_collection_duplicates):
     # make sure we only have one result
     assert result.n_molecules == 1
     assert result.n_results == 1
+
+
+@pytest.mark.parametrize("min_conformers, n_expected_results", [(1, 2), (3, 0)])
+def test_min_conformers_filter(
+    optimization_result_collection_duplicates, min_conformers, n_expected_results
+):
+
+    min_conformers_filter = MinimumConformersFilter(min_conformers=min_conformers)
+
+    assert optimization_result_collection_duplicates.n_results == 2
+    assert optimization_result_collection_duplicates.n_molecules == 1
+
+    result = min_conformers_filter.apply(
+        result_collection=optimization_result_collection_duplicates
+    )
+
+    assert result.n_results == n_expected_results
 
 
 @pytest.mark.parametrize(

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -26,12 +26,13 @@ from openff.qcsubmit.results.filters import (
     ElementFilter,
     HydrogenBondFilter,
     LowestEnergyFilter,
+    MinimumConformersFilter,
     RecordStatusFilter,
     ResultFilter,
     ResultRecordFilter,
     SMARTSFilter,
     SMILESFilter,
-    UnperceivableStereoFilter, MinimumConformersFilter,
+    UnperceivableStereoFilter,
 )
 from openff.qcsubmit.tests.results import mock_optimization_result_collection
 


### PR DESCRIPTION
## Description

This PR adds a new filter that only retains records for associated with a particular unique molecule if that molecule has a certain number of records (i.e. conformers) associated with it.

This is useful, for example, when you want to train to relative energies and hence need to make sure there are at least 2 conformers present. This is especially true when used in conjunction with the `ConformerRMSDFilter`.

## Status
- [ ] Ready to go