### PR TITLE
Switch results to fix hydrogen inchikey

### DIFF
--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -493,7 +493,7 @@ class SMILESFilter(CMILESResultFilter):
     @staticmethod
     def _smiles_to_inchi_key(smiles: str) -> str:
         return Molecule.from_smiles(smiles, allow_undefined_stereo=True).to_inchikey(
-            fixed_hydrogens=False
+            fixed_hydrogens=True
         )
 
     def _filter_function(self, entry: "_BaseResult") -> bool:

--- a/openff/qcsubmit/tests/results/__init__.py
+++ b/openff/qcsubmit/tests/results/__init__.py
@@ -58,7 +58,7 @@ def mock_basic_result_collection(molecules, monkeypatch) -> BasicResultCollectio
                 BasicResult(
                     record_id=ObjectId(str(i + 1)),
                     cmiles=molecule.to_smiles(mapped=True),
-                    inchi_key=molecule.to_inchikey(),
+                    inchi_key=molecule.to_inchikey(fixed_hydrogens=True),
                 )
                 for i, molecule in enumerate(molecules[address])
             ]
@@ -101,7 +101,7 @@ def mock_optimization_result_collection(
                 OptimizationResult(
                     record_id=ObjectId(str(i + 1)),
                     cmiles=molecule.to_smiles(mapped=True),
-                    inchi_key=molecule.to_inchikey(),
+                    inchi_key=molecule.to_inchikey(fixed_hydrogens=True),
                 )
                 for i, molecule in enumerate(molecules[address])
             ]
@@ -149,7 +149,7 @@ def mock_torsion_drive_result_collection(
                 TorsionDriveResult(
                     record_id=ObjectId(str(i + 1)),
                     cmiles=molecule.to_smiles(mapped=True),
-                    inchi_key=molecule.to_inchikey(),
+                    inchi_key=molecule.to_inchikey(fixed_hydrogens=True),
                 )
                 for i, molecule in enumerate(molecules[address])
             ]

--- a/openff/qcsubmit/tests/results/conftest.py
+++ b/openff/qcsubmit/tests/results/conftest.py
@@ -44,6 +44,18 @@ def basic_result_collection(monkeypatch) -> BasicResultCollection:
 
 
 @pytest.fixture()
+def tautomer_basic_result_collection(monkeypatch) -> BasicResultCollection:
+    """Create a basic result collection with tautomers."""
+
+    smiles = {
+        "http://localhost:442": [
+            _smiles_to_molecule(smiles) for smiles in ["Oc1nnccn1", "C1=NC(=O)NN=C1", "C1=CN=NC(=O)N1"]
+        ]
+    }
+    return mock_basic_result_collection(smiles, monkeypatch)
+
+
+@pytest.fixture()
 def h_bond_basic_result_collection(monkeypatch) -> BasicResultCollection:
     """Create a basic collection which can be filtered."""
 

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -143,6 +143,18 @@ def test_molecule_filter_apply(result_filter, expected_ids, basic_result_collect
         }
 
 
+def test_molecule_filter_tautomers(tautomer_basic_result_collection):
+    """Filter for only one tautomer to ensure we are using the fixed hydrogen inchikey."""
+
+    result_filter = SMILESFilter(smiles_to_include=["C1=NC(=O)NN=C1"])
+
+    filtered_collection = result_filter.apply(tautomer_basic_result_collection)
+
+    assert filtered_collection.n_molecules == 1
+    assert len(filtered_collection.entries["http://localhost:442"]) == 1
+    assert filtered_collection.entries["http://localhost:442"][0].record_id == "2"
+
+
 @pytest.mark.parametrize(
     "result_filter, expected_ids",
     [


### PR DESCRIPTION
## Description
This PR updates the results classes and filters to use the fixed hydrogen map inchi key to ensure tautomers are correctly distinguished. 


## Status
- [x] Ready to go