### PR TITLE
Testing fixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: devtools/conda-envs/${{ matrix.cfg.conda-env }}.yaml
@@ -51,6 +51,10 @@ jobs:
           auto-update-conda: true
           auto-activate-base: false
           show-channel-urls: true
+          mamba-version: "*"
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
 
       - name: License OpenEye
         shell: bash -l {0}

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -17,7 +17,7 @@ dependencies:
   - codecov
   - requests-mock
 
-  - qcengine >=0.20.0
+  - qcengine >=0.18.0
   - qcelemental <0.23.0
   - qcfractal
 

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -17,7 +17,8 @@ dependencies:
   - codecov
   - requests-mock
 
-  - qcengine >=0.18.0
+  - qcengine >=0.20.0
+  - qcelemental <0.23.0
   - qcfractal
 
   - openeye-toolkits

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -18,11 +18,12 @@ dependencies:
   - codecov
   - requests-mock
 
-  - qcengine >=0.18.0
+  - qcengine >=0.20.0
+  - qcelemental >0.23.0
   - qcfractal
-  - psi4 >=1.4a2
-  - gau2grid =2.0.3
-  - pcmsolver =1.2.1
+  - psi4 >=1.4
+  - gau2grid
+  - pcmsolver
 
   - openeye-toolkits
 

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -18,7 +18,7 @@ dependencies:
   - codecov
   - requests-mock
 
-  - qcengine >=0.20.0
+  - qcengine >=0.18.0
   - qcelemental <0.23.0
   - qcfractal
   - psi4 >=1.4a2

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -3,7 +3,7 @@ name: test
 channels:
   - openeye
   - conda-forge
-  - psi4
+  - psi4/label/dev
   - defaults
 
 dependencies:
@@ -21,9 +21,9 @@ dependencies:
   - qcengine >=0.20.0
   - qcelemental <0.23.0
   - qcfractal
-  - psi4 >=1.4
-  - gau2grid
-  - pcmsolver
+  - psi4 >=1.4a2
+  - gau2grid =2.0.3
+  - pcmsolver =1.2.1
 
   - openeye-toolkits
 

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -19,7 +19,7 @@ dependencies:
   - requests-mock
 
   - qcengine >=0.20.0
-  - qcelemental >0.23.0
+  - qcelemental <0.23.0
   - qcfractal
   - psi4 >=1.4
   - gau2grid

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -3,8 +3,8 @@ name: test
 channels:
   - openeye
   - conda-forge
+  - psi4
   - defaults
-  - psi4/label/dev
 
 dependencies:
 


### PR DESCRIPTION
## Description
Try and pin qcelemental to fix the psi4 local compute tests.

The psi4 CI testing seems to have broken around the time of the new `qcelemental=0.23.0` release. The error is due to a numpy array not being converted to a list before trying to form the JSON when saving results in a qcfractal db. Unfortunately the error is truncated in the CI report so we can't see which property is causing the issue. 

```
File "/usr/share/miniconda/envs/test/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
sqlalchemy.exc.StatementError: (builtins.TypeError) Object of type ndarray is not JSON serializable
[SQL: INSERT INTO result (id, program, driver, method, basis, molecule, keywords, return_result, properties, wavefunction, wavefunction_data_id) VALUES (%(id)s, %(program)s, %(driver)s, %(method)s, %(basis)s, %(molecule)s, %(keywords)s, %(return_result)s, %(properties)s, %(wavefunction)s, %(wavefunction_data_id)s)]
[parameters: [{'properties': {'calcinfo_nbasis': 9, 'calcinfo_nmo': 9, 'calcinfo_nalpha': 5, 'calcinfo_nbeta': 5, 'calcinfo_natom': 5, 'nuclear_repulsion_energy':  ... (4300 characters truncated) ...  'method': 'hf', 'wavefunction': None, 'basis': 'sto-3g', 'keywords': '2', 'driver': <DriverEnum.gradient: 'gradient'>, 'wavefunction_data_id': None}]]
```

## Status
- [x] Ready to go