### PR TITLE
Use of `additional_keywords` for per-torsiondrive-entry constraints

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -18,7 +18,7 @@ dependencies:
   - requests-mock
 
   - qcengine >=0.18.0
-  - qcelemental <0.23.0
+  - qcelemental
   - qcfractal
 
   - openeye-toolkits

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -19,7 +19,7 @@ dependencies:
 
   - qcengine >=0.18.0
   - qcelemental
-  - qcfractal
+  - qcfractal>=0.15.7
 
   - openeye-toolkits
 
@@ -29,7 +29,7 @@ dependencies:
   - rdkit
   - pydantic
   - pyyaml
-  - qcportal
+  - qcportal>=0.15.7
   - torsiondrive
   - basis_set_exchange
   - typing-extensions

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -20,7 +20,7 @@ dependencies:
 
   - qcengine >=0.18.0
   - qcelemental
-  - qcfractal
+  - qcfractal>=0.15.7
   - psi4 >=1.4a2
   - gau2grid =2.0.3
   - pcmsolver =1.2.1
@@ -33,7 +33,7 @@ dependencies:
   - rdkit
   - pydantic
   - pyyaml
-  - qcportal
+  - qcportal>=0.15.7
   - torsiondrive
   - basis_set_exchange
   - typing-extensions

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -19,7 +19,7 @@ dependencies:
   - requests-mock
 
   - qcengine >=0.18.0
-  - qcelemental <0.23.0
+  - qcelemental
   - qcfractal
   - psi4 >=1.4a2
   - gau2grid =2.0.3

--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -143,6 +143,10 @@ class TDSettings(DatasetConfig):
         "start new optimizations, in unit of a.u. I.e. if energy_upper_limit = 0.05, current global "
         "minimum energy is -9.9 , then a new task starting with energy -9.8 will be skipped.",
     )
+    additional_keywords: Dict[str, Any] = Field(
+        {},
+        description="Additional keywords to add to the torsiondrive's optimization runs"
+    )
 
 
 class PCMSettings(ResultsConfig):

--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -145,7 +145,7 @@ class TDSettings(DatasetConfig):
     )
     additional_keywords: Dict[str, Any] = Field(
         {},
-        description="Additional keywords to add to the torsiondrive's optimization runs"
+        description="Additional keywords to add to the torsiondrive's optimization runs",
     )
 
 

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -1613,6 +1613,7 @@ class TorsiondriveDataset(OptimizationDataset):
                 grid_spacing=data.keywords.grid_spacing or self.grid_spacing,
                 energy_upper_limit=data.keywords.energy_upper_limit
                 or self.energy_upper_limit,
+                additional_keywords=data.keywords.additional_keywords,
                 attributes=data.attributes.dict(),
                 energy_decrease_thresh=data.keywords.energy_decrease_thresh
                 or self.energy_decrease_thresh,


### PR DESCRIPTION
## Description
Along with MolSSI/QCFractal#693, addresses #167.

## Status
- [x] Ready to go