### PR TITLE
Fix dftd3 compute updates

### DIFF
--- a/openff/qcsubmit/datasets/dataset_utils.py
+++ b/openff/qcsubmit/datasets/dataset_utils.py
@@ -112,13 +112,15 @@ def update_specification_and_metadata(
         # now we need to add each ran spec
         for history in ds.data.history:
             _, program, method, basis, spec = history
-            dataset.add_qc_spec(
-                method=method,
-                basis=basis,
-                program=program,
-                spec_name=spec,
-                spec_description="basic dataset spec",
-            )
+            if program.lower() != "dftd3":
+                # the composition planner breaks the validation
+                dataset.add_qc_spec(
+                    method=method,
+                    basis=basis,
+                    program=program,
+                    spec_name=spec,
+                    spec_description="basic dataset spec",
+                )
     else:
         # we have the opt or torsiondrive
         if not dataset.metadata.elements:

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -655,7 +655,7 @@ def test_add_molecule_no_extras():
 
 
 @pytest.mark.parametrize("dataset_data", [
-    pytest.param((BasicDataset, "OpenFF NCI250K Boron 1", ["default"]), id="Dataset no metadata"),
+    pytest.param((BasicDataset, "OpenFF Theory Benchmarking Single Point Energies v1.0", ["default"]), id="Dataset no metadata"),
     pytest.param((OptimizationDataset, "OpenFF NCI250K Boron 1", ["default"]), id="OptimizationDataset no metadata"),
     pytest.param((TorsiondriveDataset, "OpenFF Fragmenter Phenyl Benchmark", ["UFF", "B3LYP-D3"]), id="TorsiondriveDataset no metadata"),
     pytest.param((TorsiondriveDataset, "OpenFF Rowley Biaryl v1.0", ["default"]), id="Torsiondrive with metadata")


### PR DESCRIPTION
## Description
This PR will stop qcsubmit rasing a specification validation error when loading a dataset with a dftd3 split specification. That spec is now skipped as the joint spec still contains the same information but with the correct program. 

## Status
- [X] Ready to go