### PR TITLE
Clear Error for missing inputs

### DIFF
--- a/openff/qcsubmit/factories.py
+++ b/openff/qcsubmit/factories.py
@@ -357,6 +357,8 @@ class BaseDatasetFactory(CommonBase, abc.ABC):
                     ),
                     input_directory=molecules,
                 )
+            else:
+                raise FileNotFoundError(f"The input {molecules} could not be found.")
 
         elif isinstance(molecules, off.Molecule):
             workflow_molecules = ComponentResult(

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -204,9 +204,9 @@ def test_componetresult_directory():
 
 
 @pytest.mark.parametrize("file_name", [
-    # pytest.param("benzene.sdf", id="SDF file"),
-    # pytest.param("butane_conformers.pdb", id="PDB file"),
-    # pytest.param("tautomers_small.smi", id="SMI file"),
+    pytest.param("benzene.sdf", id="SDF file"),
+    pytest.param("butane_conformers.pdb", id="PDB file"),
+    pytest.param("tautomers_small.smi", id="SMI file"),
     pytest.param("hdf5-example.hdf5", id="HDF5 file")
 ])
 def test_componetresult_input_file(file_name):
@@ -217,7 +217,6 @@ def test_componetresult_input_file(file_name):
                              component_description={},
                              component_provenance={},
                              input_file=get_data(file_name))
-    print(result.molecules)
     assert result.n_molecules > 0
 
 

--- a/openff/qcsubmit/tests/test_factories.py
+++ b/openff/qcsubmit/tests/test_factories.py
@@ -450,6 +450,20 @@ def test_torsiondrive_torsion_string():
     assert torsion in reference_torsions or tuple(reversed(torsion)) in reference_torsions
 
 
+def test_create_dataset_missing_input():
+    """
+    Make sure an error is raised if the input can not be found.
+    """
+    factory = BasicDatasetFactory()
+    with pytest.raises(FileNotFoundError, match="The input missing_file.smi could not be found."):
+        _ = factory.create_dataset(
+            dataset_name="test dataset",
+            tagline="test dataset",
+            description="test dataset",
+            molecules="missing_file.smi"
+        )
+
+
 @pytest.mark.parametrize("factory_dataset_type", [
     pytest.param((BasicDatasetFactory, BasicDataset), id="BasicDatasetFactory"),
     pytest.param((OptimizationDatasetFactory, OptimizationDataset), id="OptimizationDatasetFactory"),


### PR DESCRIPTION
## Description
This PR makes the dataset factories raise a `FileNotFound` error when the input file can not be found. This is an improvement over the current unbound local error. 

## Status
- [X] Ready to go