### PR TITLE
Only call `Molecule.from_openff_molecule` if 'attributes' not present in `Dataset.add_molecule` kwargs

### DIFF
--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -595,7 +595,7 @@ class _BaseDataset(abc.ABC, CommonBase):
     def add_molecule(
         self,
         index: str,
-        molecule: off.Molecule,
+        molecule: Optional[off.Molecule],
         extras: Optional[Dict[str, Any]] = None,
         keywords: Optional[Dict[str, Any]] = None,
         **kwargs,

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -619,8 +619,8 @@ class _BaseDataset(abc.ABC, CommonBase):
         """
         # only use attributes if supplied else generate
         # Note we should only reuse attributes if making a dataset from a result so the attributes are consistent
-        if 'attributes' in kwargs:
-            attributes = kwargs.pop('attributes')
+        if "attributes" in kwargs:
+            attributes = kwargs.pop("attributes")
         else:
             attributes = MoleculeAttributes.from_openff_molecule(molecule=molecule)
 

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -619,9 +619,10 @@ class _BaseDataset(abc.ABC, CommonBase):
         """
         # only use attributes if supplied else generate
         # Note we should only reuse attributes if making a dataset from a result so the attributes are consistent
-        attributes = kwargs.pop(
-            "attributes", MoleculeAttributes.from_openff_molecule(molecule=molecule)
-        )
+        if 'attributes' in kwargs:
+            attributes = kwargs.pop('attributes')
+        else:
+            attributes = MoleculeAttributes.from_openff_molecule(molecule=molecule)
 
         try:
             data_entry = self._entry_class()(

--- a/openff/qcsubmit/datasets/entries.py
+++ b/openff/qcsubmit/datasets/entries.py
@@ -74,7 +74,7 @@ class DatasetEntry(DatasetConfig):
         This is needed to make sure the extras are passed into the qcschema molecule.
         """
 
-        extras = kwargs["extras"]
+        extras = kwargs.get("extras", {})
         # a place holder to check for multiple components
         molecule_ids, charges = None, None
         # if we get an off_molecule we need to convert it

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -659,6 +659,25 @@ def test_add_molecule_no_extras():
             assert mol.fix_symmetry == "c1"
 
 
+def test_add_molecule_from_entry_data():
+    """
+    Test adding a molecule to a dataset from the entry info which has no openff.Molecule instance.
+    """
+    dataset = BasicDataset(
+        dataset_name="Test dataset",
+        dataset_tagline="XXXXXXXX",
+        description="XXXXXXXX",
+    )
+    ethane = Molecule.from_smiles("CC")
+    ethane.generate_conformers()
+    entry = DatasetEntry(
+        off_molecule=ethane,
+        attributes=MoleculeAttributes.from_openff_molecule(ethane),
+        index="1"
+    )
+    dataset.add_molecule(molecule=None, **entry.dict())
+
+
 @pytest.mark.parametrize("dataset_data", [
     pytest.param((BasicDataset, "OpenFF Theory Benchmarking Single Point Energies v1.0", ["default"]), id="Dataset no metadata"),
     pytest.param((OptimizationDataset, "OpenFF NCI250K Boron 1", ["default"]), id="OptimizationDataset no metadata"),


### PR DESCRIPTION
Currently, [we observe failures](https://github.com/openforcefield/qca-dataset-submission/runs/4459934379?check_suite_focus=true#step:8:24) when calling `Dataset.add_molecule` when feeding in `molecule=None`, whereas this was permitted previously.

This appears due to the use of `kwargs.pop`, with `MoleculeAttributes.from_openff_molecule(molecule=molecule)` as the default value. This gets called even if 'attributes' is present as a key in the dictionary. This PR separates these operations to avoid this call.

## Status
- [x] Ready to go