### PR TITLE
Result collections with None inchikeys

### DIFF
--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -443,16 +443,13 @@ class OptimizationResultCollection(_BaseResultCollection):
                         cmiles=entry.attributes[
                             "canonical_isomeric_explicit_hydrogen_mapped_smiles"
                         ],
-                        inchi_key=entry.attributes.get(
-                            "fixed_hydrogen_inchi_key",
-                            # if this is missing on old records generate it
-                            Molecule.from_mapped_smiles(
-                                entry.attributes[
-                                    "canonical_isomeric_explicit_hydrogen_mapped_smiles"
-                                ],
-                                allow_undefined_stereo=True,
-                            ).to_inchikey(fixed_hydrogens=True),
-                        ),
+                        inchi_key=entry.attributes.get("fixed_hydrogen_inchi_key")
+                        or Molecule.from_mapped_smiles(
+                            entry.attributes[
+                                "canonical_isomeric_explicit_hydrogen_mapped_smiles"
+                            ],
+                            allow_undefined_stereo=True,
+                        ).to_inchikey(fixed_hydrogens=True),
                     )
                     for entry in dataset.data.records.values()
                     if entry.name in query
@@ -687,15 +684,13 @@ class TorsionDriveResultCollection(_BaseResultCollection):
                         cmiles=entry.attributes[
                             "canonical_isomeric_explicit_hydrogen_mapped_smiles"
                         ],
-                        inchi_key=entry.attributes.get(
-                            "fixed_hydrogen_inchi_key",
-                            Molecule.from_mapped_smiles(
-                                entry.attributes[
-                                    "canonical_isomeric_explicit_hydrogen_mapped_smiles"
-                                ],
-                                allow_undefined_stereo=True,
-                            ).to_inchikey(fixed_hydrogens=True),
-                        ),
+                        inchi_key=entry.attributes.get("fixed_hydrogen_inchi_key")
+                        or Molecule.from_mapped_smiles(
+                            entry.attributes[
+                                "canonical_isomeric_explicit_hydrogen_mapped_smiles"
+                            ],
+                            allow_undefined_stereo=True,
+                        ).to_inchikey(fixed_hydrogens=True),
                     )
                     for entry in dataset.data.records.values()
                     if entry.name in query

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -262,6 +262,8 @@ class BasicResultCollection(_BaseResultCollection):
     """A class which stores a reference to, and allows the retrieval of, data from
     a single result record stored in a QCFractal instance."""
 
+    type: Literal["BasicResultCollection"] = "BasicResultCollection"
+
     entries: Dict[str, List[BasicResult]] = Field(
         ...,
         description="The entries stored in this collection in a dictionary of the form "
@@ -405,6 +407,8 @@ class OptimizationResult(_BaseResult):
 class OptimizationResultCollection(_BaseResultCollection):
     """A class which stores a reference to, and allows the retrieval of, data from
     a single optimization result record stored in a QCFractal instance."""
+
+    type: Literal["OptimizationResultCollection"] = "OptimizationResultCollection"
 
     entries: Dict[str, List[OptimizationResult]] = Field(
         ...,
@@ -647,6 +651,8 @@ class TorsionDriveResultCollection(_BaseResultCollection):
     """A class which stores a reference to, and allows the retrieval of, data from
     a single torsion drive result record stored in a QCFractal instance."""
 
+    type: Literal["TorsionDriveResultCollection"] = "TorsionDriveResultCollection"
+    
     entries: Dict[str, List[TorsionDriveResult]] = Field(
         ...,
         description="The entries stored in this collection in a dictionary of the form "

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -652,7 +652,7 @@ class TorsionDriveResultCollection(_BaseResultCollection):
     a single torsion drive result record stored in a QCFractal instance."""
 
     type: Literal["TorsionDriveResultCollection"] = "TorsionDriveResultCollection"
-    
+
     entries: Dict[str, List[TorsionDriveResult]] = Field(
         ...,
         description="The entries stored in this collection in a dictionary of the form "


### PR DESCRIPTION
## Description
This PR has a workaround for loading datasets with the fixed hydrgoen inchi key set to `None` such as the `OpenFF-benchmark-ligand-fragments-v2.0` dataset which contains a mix of new and old calculations. 
Types are also added to the collections so that they can be distinguished before loading into a model. 

## Status
- [x] Ready to go