### PR TITLE
Fix dataset record queries with nans

### DIFF
--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -339,7 +339,7 @@ class PCMSettings(ResultsConfig):
             if "cavity_Area" not in kwargs:
                 cavity_Area = (
                     self.__fields__["cavity_Area"].default
-                    * constants.bohr2angstroms ** 2
+                    * constants.bohr2angstroms**2
                 )
                 kwargs["cavity_Area"] = cavity_Area
         super(PCMSettings, self).__init__(**kwargs)

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -306,7 +306,12 @@ class BasicResultCollection(_BaseResultCollection):
                 )
 
             # query the database to get all of the result records requested
-            query = dataset.get_records(**dataset_specs[spec_name])
+            query = dataset.get_records(
+                **dataset_specs[spec_name],
+                status=[
+                    "COMPLETE",
+                ],
+            )
 
             entries: Dict[str, MoleculeEntry] = {
                 entry.name: entry for entry in dataset.data.records
@@ -346,7 +351,8 @@ class BasicResultCollection(_BaseResultCollection):
                         ).to_inchikey(fixed_hydrogens=True),
                     )
                     for index, (result,) in query.iterrows()
-                    if result.status.value.upper() == "COMPLETE"
+                    if isinstance(result, ResultRecord)
+                    and result.status.value.upper() == "COMPLETE"
                 }
             )
 

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -244,8 +244,8 @@ def test_base_smirnoff_coverage():
             BasicResultCollection,
             "OpenFF BCC Refit Study COH v1.0",
             "resp-2-vacuum",
-            94,
-            429,
+            91,
+            381,
         ),
         (
             OptimizationResultCollection,


### PR DESCRIPTION
## Description
This PR is a simple fix for creating basic dataset results from collections with NaNs, representing records to be computed. See [here](https://github.com/MolSSI/QCFractal/issues/706) for a better fix that won't involve qcsubmit doing a second filter. 


## Status
- [X] Ready to go