### PR TITLE
keep multiple conformers when creating a basic dataset from an `OptimizationResultCollection`

### DIFF
--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -339,7 +339,7 @@ class PCMSettings(ResultsConfig):
             if "cavity_Area" not in kwargs:
                 cavity_Area = (
                     self.__fields__["cavity_Area"].default
-                    * constants.bohr2angstroms**2
+                    * constants.bohr2angstroms ** 2
                 )
                 kwargs["cavity_Area"] = cavity_Area
         super(PCMSettings, self).__init__(**kwargs)

--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -339,7 +339,7 @@ class PCMSettings(ResultsConfig):
             if "cavity_Area" not in kwargs:
                 cavity_Area = (
                     self.__fields__["cavity_Area"].default
-                    * constants.bohr2angstroms ** 2
+                    * constants.bohr2angstroms**2
                 )
                 kwargs["cavity_Area"] = cavity_Area
         super(PCMSettings, self).__init__(**kwargs)

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -407,7 +407,7 @@ def test_optimization_create_basic_dataset(optimization_result_collection):
 
     assert dataset.dataset_name == "new basicdataset"
     assert dataset.n_molecules == 4
-    assert dataset.n_records == 4  # the collection contains 1 duplicate so not 4 not 5.
+    assert dataset.n_records == 5  # the collection contains 1 duplicate
 
     
 def test_optimization_to_basic_result_collection(


### PR DESCRIPTION
## Description
This PR fixes a bug where an `OptimizationResultCollection` will drop multiple conformers for molecules when creating a basic dataset from the result. 


## Status
- [x] Ready to go