### PR TITLE
Expose trajectory protocol for optimization datasets

### DIFF
--- a/openff/qcsubmit/datasets/dataset_utils.py
+++ b/openff/qcsubmit/datasets/dataset_utils.py
@@ -143,6 +143,7 @@ def update_specification_and_metadata(
                 spec_name=spec.name,
                 spec_description=spec.description,
                 store_wavefunction=spec.qc_spec.protocols.wavefunction.value,
+                optimization_trajectory=spec.qc_spec.protocols.trajectory.value,
             )
 
     return dataset

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -1272,7 +1272,7 @@ class OptimizationDataset(BasicDataset):
             basis=spec.basis,
             keywords=keyword_id,
             program=spec.program,
-            protocols={"wavefunction": spec.store_wavefunction},
+            protocols={"trajectory": spec.optimization_trajectory},
         )
 
         return qc_spec


### PR DESCRIPTION

## Description

We set the default trajectory protocol for optimizations to be
`initial_and_final` in order to conserve space where possible.
Choosing another option is an opt-in choice for the submitter.

## Status
- [ ] Ready to go
