### PR TITLE
Toolkit 0.11 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.7
-          # - 3.8
+          - 3.8
           # - 3.9
+          # - 3.10
         cfg:
           - os: ubuntu-latest
             conda-env: basic

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -25,7 +25,8 @@ dependencies:
 
   ### Core dependencies.
 
-  - openff-toolkit-base
+  - openff-toolkit-base >= 0.11
+  - openff-units
   - rdkit
   - pydantic
   - pyyaml

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -18,8 +18,8 @@ dependencies:
   - codecov
   - requests-mock
 
-  - qcengine >=0.20.0
-  - qcelemental >=0.23.0
+  - qcengine >=0.25
+  - qcelemental >=0.25.1
   - qcfractal>=0.15.7
 
   - openeye-toolkits

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -29,6 +29,7 @@ dependencies:
   # openmmforcefields brings in the full toolkit; if that is ever re-packaged
   # this should be changed to openff-toolkit-base
   - openff-toolkit >= 0.11.3
+  - importlib_metadata <5
   - rdkit
   - pydantic
   - pyyaml

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -29,6 +29,9 @@ dependencies:
   # openmmforcefields brings in the full toolkit; if that is ever re-packaged
   # this should be changed to openff-toolkit-base
   - openff-toolkit >= 0.11.3
+  # argcomplete (brought it via BSE) pulls down totally incorrect builds of `importlib_metadata`,
+  - importlib_metadata >=4
+  - importlib-metadata >=4
   - rdkit
   - pydantic
   - pyyaml

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -29,7 +29,7 @@ dependencies:
   # openmmforcefields brings in the full toolkit; if that is ever re-packaged
   # this should be changed to openff-toolkit-base
   - openff-toolkit >= 0.11.3
-  # argcomplete (brought it via BSE) pulls down totally incorrect builds of `importlib_metadata`,
+  # argcomplete (brought in via BSE) pulls down totally incorrect builds of `importlib_metadata`,
   - importlib_metadata >=4
   - importlib-metadata >=4
   - rdkit

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -14,6 +14,7 @@ dependencies:
   # Testing
   - pytest
   - pytest-cov
+  - pytest-xdist
   - codecov
   - requests-mock
 

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -26,7 +26,7 @@ dependencies:
 
   ### Core dependencies.
 
-  - openff-toolkit-base >= 0.11
+  - openff-toolkit-base >= 0.11.2
   - openff-units
   - rdkit
   - pydantic
@@ -43,5 +43,4 @@ dependencies:
   - openff-fragmenter-base >=0.2.0
 
   - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@main
     - git+https://github.com/MolSSI/QCEngine@master

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -29,7 +29,6 @@ dependencies:
   # openmmforcefields brings in the full toolkit; if that is ever re-packaged
   # this should be changed to openff-toolkit-base
   - openff-toolkit >= 0.11.3
-  - importlib_metadata <5
   - rdkit
   - pydantic
   - pyyaml
@@ -43,6 +42,3 @@ dependencies:
   # Optional
   - openmmforcefields
   - openff-fragmenter-base >=0.2.0
-
-  - pip:
-    - git+https://github.com/MolSSI/QCEngine@master

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -40,6 +40,8 @@ dependencies:
 
   # Optional
   - openmmforcefields >=0.9.0
-  - openff-fragmenter-base
-#  - pip:
-#      - git+https://github.com/openforcefield/openff-fragmenter.git@master
+  - openff-fragmenter-base >=0.2.0
+
+  - pip:
+    - git+https://github.com/openforcefield/openff-toolkit.git@main
+    - git+https://github.com/MolSSI/QCEngine@master

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -1,4 +1,4 @@
-name: test
+name: qcsubmit-test-basic
 
 channels:
   - openeye
@@ -26,7 +26,9 @@ dependencies:
 
   ### Core dependencies.
 
-  - openff-toolkit-base >= 0.11.3
+  # openmmforcefields brings in the full toolkit; if that is ever re-packaged
+  # this should be changed to openff-toolkit-base
+  - openff-toolkit >= 0.11.3
   - rdkit
   - pydantic
   - pyyaml
@@ -38,7 +40,7 @@ dependencies:
   - h5py>=3.6.0
 
   # Optional
-  - openmmforcefields >=0.9.0
+  - openmmforcefields
   - openff-fragmenter-base >=0.2.0
 
   - pip:

--- a/devtools/conda-envs/docs.yaml
+++ b/devtools/conda-envs/docs.yaml
@@ -20,7 +20,8 @@ dependencies:
   - ipython
 
     # Standard dependencies
-  - openff-toolkit-base
+  - openff-toolkit-base >= 0.11
+  - openff-units
 #  - rdkit                MOCKED
   - pydantic
   - pyyaml

--- a/devtools/conda-envs/docs.yaml
+++ b/devtools/conda-envs/docs.yaml
@@ -24,6 +24,7 @@ dependencies:
 
     # Standard dependencies
   - openff-toolkit-base >= 0.11.2
+  - importlib_metadata <5
 #  - rdkit                MOCKED
   - pydantic
   - pyyaml

--- a/devtools/conda-envs/docs.yaml
+++ b/devtools/conda-envs/docs.yaml
@@ -23,7 +23,7 @@ dependencies:
   - ipython
 
     # Standard dependencies
-  - openff-toolkit-base >= 0.11
+  - openff-toolkit-base >= 0.11.2
   - openff-units
 #  - rdkit                MOCKED
   - pydantic
@@ -38,4 +38,3 @@ dependencies:
   - pip:
     - autodoc_pydantic
     - git+https://github.com/openforcefield/openff-sphinx-theme.git@main
-    - git+https://github.com/openforcefield/openff-toolkit.git@main

--- a/devtools/conda-envs/docs.yaml
+++ b/devtools/conda-envs/docs.yaml
@@ -1,5 +1,7 @@
 name: qcsubmit
 channels:
+  # Avoids crashing RTD machines by pulling an empty cudatoolkit pacakge
+  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 
 dependencies:
@@ -10,6 +12,7 @@ dependencies:
   - setuptools
 
   # Sphinx specific
+  - sphinx >=4.4,<5.0
   - nbsphinx
   - nbsphinx-link
   - sphinx_rtd_theme
@@ -30,6 +33,7 @@ dependencies:
   - basis_set_exchange
   - typing-extensions
   - cachetools
+  - openmm
 
   - pip:
       - autodoc_pydantic

--- a/devtools/conda-envs/docs.yaml
+++ b/devtools/conda-envs/docs.yaml
@@ -36,5 +36,6 @@ dependencies:
   - openmm
 
   - pip:
-      - autodoc_pydantic
-      - git+https://github.com/openforcefield/openff-sphinx-theme.git@main
+    - autodoc_pydantic
+    - git+https://github.com/openforcefield/openff-sphinx-theme.git@main
+    - git+https://github.com/openforcefield/openff-toolkit.git@main

--- a/devtools/conda-envs/docs.yaml
+++ b/devtools/conda-envs/docs.yaml
@@ -24,7 +24,6 @@ dependencies:
 
     # Standard dependencies
   - openff-toolkit-base >= 0.11.2
-  - importlib_metadata <5
 #  - rdkit                MOCKED
   - pydantic
   - pyyaml

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -3,7 +3,7 @@ name: test
 channels:
   - openeye
   - conda-forge
-  - psi4/label/dev
+  - psi4
   - defaults
 
 dependencies:
@@ -22,7 +22,7 @@ dependencies:
   - qcelemental >=0.23.0
   - qcfractal >=0.15.7
   - qcfractal-core >=0.15.7
-  - psi4 =1.4a2.dev1058+670a850
+  - psi4 >=1.4
   - gau2grid =2.0.3
 
   - openeye-toolkits

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -9,7 +9,7 @@ channels:
 dependencies:
 
   # Base depends
-  - python
+  - python>=3.8
   - pip
 
   # Testing
@@ -22,10 +22,14 @@ dependencies:
   - qcelemental >=0.23.0
   - qcfractal >=0.15.7
   - qcfractal-core >=0.15.7
-  - psi4 >=1.4
-  - gau2grid =2.0.3
 
   - openeye-toolkits
+
+  # Psi4 dependencies
+  - psi4 =1.5
+  - libint2=*=hc9558a2_9
+  - intel-openmp!=2019.5
+  - gau2grid >=2.0
 
   ### Core dependencies.
 
@@ -44,6 +48,6 @@ dependencies:
   # Optional
   - openmmforcefields >=0.9.0  # can not install ambertools with psi4
   - openff-fragmenter-base
-  - openmm <7.6
+  - openmm
 #  - pip:
 #      - git+https://github.com/openforcefield/openff-fragmenter.git@master

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -50,3 +50,4 @@ dependencies:
   - openmm
   - pip:
     - git+https://github.com/openforcefield/openff-toolkit.git@main
+    - git+https://github.com/MolSSI/QCEngine@master

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -18,8 +18,8 @@ dependencies:
   - codecov
   - requests-mock
 
-  - qcengine >=0.20.0
-  - qcelemental >=0.23.0
+  - qcengine >=0.25
+  - qcelemental >=0.25.1
   - qcfractal >=0.15.7
   - qcfractal-core >=0.15.7
 

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -4,6 +4,7 @@ channels:
   - psi4
   - conda-forge
   - openeye
+  - defaults
 
 dependencies:
 

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -34,7 +34,7 @@ dependencies:
   ### Core dependencies.
 
   - openff-toolkit-base >= 0.11.3
-  # argcomplete (brought it via BSE) pulls down totally incorrect builds of `importlib_metadata`,
+  # argcomplete (brought in via BSE) pulls down totally incorrect builds of `importlib_metadata`,
   - importlib_metadata >=4
   - importlib-metadata >=4
   - rdkit

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -29,7 +29,8 @@ dependencies:
 
   ### Core dependencies.
 
-  - openff-toolkit-base
+  - openff-toolkit-base >= 0.11
+  - openff-units
   - rdkit
   - pydantic
   - pyyaml

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -34,6 +34,9 @@ dependencies:
   ### Core dependencies.
 
   - openff-toolkit-base >= 0.11.3
+  # argcomplete (brought it via BSE) pulls down totally incorrect builds of `importlib_metadata`,
+  - importlib_metadata >=4
+  - importlib-metadata >=4
   - rdkit
   - pydantic
   - pyyaml

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -32,7 +32,7 @@ dependencies:
 
   ### Core dependencies.
 
-  - openff-toolkit-base >= 0.11
+  - openff-toolkit-base >= 0.11.2
   - openff-units
   - rdkit
   - pydantic
@@ -49,5 +49,4 @@ dependencies:
   - openff-fragmenter-base >=0.2.0
   - openmm
   - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@main
     - git+https://github.com/MolSSI/QCEngine@master

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -34,7 +34,6 @@ dependencies:
   ### Core dependencies.
 
   - openff-toolkit-base >= 0.11.3
-  - importlib_metadata <5
   - rdkit
   - pydantic
   - pyyaml
@@ -46,8 +45,6 @@ dependencies:
   - h5py>=3.6.0
 
   # Optional
-  - openmmforcefields >=0.9.0  # can not install ambertools with psi4
+  - openmmforcefields >=0.9.0
   - openff-fragmenter-base >=0.2.0
   - openmm
-  - pip:
-    - git+https://github.com/MolSSI/QCEngine@master

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -1,4 +1,4 @@
-name: test
+name: qcsubmit-test-psi4
 
 channels:
   - psi4

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -1,10 +1,9 @@
 name: test
 
 channels:
-  - openeye
-  - conda-forge
   - psi4
-  - defaults
+  - conda-forge
+  - openeye
 
 dependencies:
 

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -46,7 +46,7 @@ dependencies:
 
   # Optional
   - openmmforcefields >=0.9.0  # can not install ambertools with psi4
-  - openff-fragmenter-base
+  - openff-fragmenter-base >=0.2.0
   - openmm
-#  - pip:
-#      - git+https://github.com/openforcefield/openff-fragmenter.git@master
+  - pip:
+    - git+https://github.com/openforcefield/openff-toolkit.git@main

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -34,6 +34,7 @@ dependencies:
   ### Core dependencies.
 
   - openff-toolkit-base >= 0.11.3
+  - importlib_metadata <5
   - rdkit
   - pydantic
   - pyyaml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ source_suffix = ".rst"
 
 master_doc = "index"
 
-language = None
+language = 'en'
 
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 

--- a/openff/qcsubmit/datasets/entries.py
+++ b/openff/qcsubmit/datasets/entries.py
@@ -143,7 +143,7 @@ class DatasetEntry(DatasetConfig):
         if include_conformers:
             for conformer in self.initial_molecules:
                 geometry = unit.Quantity(np.array(conformer.geometry), unit.bohr)
-                molecule.add_conformer(geometry.in_units_of(unit.angstrom))
+                molecule.add_conformer(geometry.to(unit.angstrom))
         return molecule
 
 

--- a/openff/qcsubmit/datasets/entries.py
+++ b/openff/qcsubmit/datasets/entries.py
@@ -7,15 +7,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import networkx as nx
 import numpy as np
 import openff.toolkit.topology as off
+from openff.units import unit
 import qcelemental as qcel
 import qcelemental.models
 from pydantic import Field, validator
 from typing_extensions import Literal
-
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 
 from openff.qcsubmit.common_structures import (
     DatasetConfig,

--- a/openff/qcsubmit/datasets/entries.py
+++ b/openff/qcsubmit/datasets/entries.py
@@ -91,7 +91,7 @@ class DatasetEntry(DatasetConfig):
             charges = [
                 sum(
                     [
-                        off_molecule.atoms[atom].formal_charge.value_in_unit(
+                        off_molecule.atoms[atom].formal_charge.m_as(
                             unit.elementary_charge
                         )
                         for atom in graph
@@ -142,7 +142,7 @@ class DatasetEntry(DatasetConfig):
         molecule.name = self.index
         if include_conformers:
             for conformer in self.initial_molecules:
-                geometry = unit.Quantity(np.array(conformer.geometry), unit=unit.bohr)
+                geometry = unit.Quantity(np.array(conformer.geometry), unit.bohr)
                 molecule.add_conformer(geometry.in_units_of(unit.angstrom))
         return molecule
 

--- a/openff/qcsubmit/datasets/entries.py
+++ b/openff/qcsubmit/datasets/entries.py
@@ -7,9 +7,9 @@ from typing import Any, Dict, List, Optional, Tuple
 import networkx as nx
 import numpy as np
 import openff.toolkit.topology as off
-from openff.units import unit
 import qcelemental as qcel
 import qcelemental.models
+from openff.units import unit
 from pydantic import Field, validator
 from typing_extensions import Literal
 

--- a/openff/qcsubmit/results/caching.py
+++ b/openff/qcsubmit/results/caching.py
@@ -7,15 +7,11 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Ty
 import numpy
 from cachetools import Cache, LRUCache
 from openff.toolkit.topology import Molecule
+from openff.units import unit
 from qcportal import FractalClient
 from qcportal.models import Molecule as QCMolecule
 from qcportal.models import TorsionDriveRecord
 from qcportal.models.records import OptimizationRecord, RecordBase, ResultRecord
-
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 
 if TYPE_CHECKING:
     from openff.qcsubmit.results.results import (

--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -610,7 +610,7 @@ class ChargeFilter(CMILESResultFilter):
         molecule: Molecule = Molecule.from_mapped_smiles(
             entry.cmiles, allow_undefined_stereo=True
         )
-        total_charge = molecule.total_charge.value_in_unit(unit.elementary_charge)
+        total_charge = molecule.total_charge.m_as(unit.elementary_charge)
 
         if self.charges_to_include is not None:
 
@@ -681,7 +681,7 @@ class HydrogenBondFilter(ResultRecordFilter):
 
         conformers = numpy.array(
             [
-                conformer.value_in_unit(unit.nanometers).tolist()
+                conformer.m_as(unit.nanometers).tolist()
                 for conformer in molecule.conformers
             ]
         )

--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -13,6 +13,7 @@ from openff.toolkit.utils import (
     RDKitToolkitWrapper,
     UndefinedStereochemistryError,
 )
+from openff.units import unit
 from pydantic import BaseModel, Field, PrivateAttr, root_validator, validator
 from qcelemental.molutil import guess_connectivity
 from qcportal.models.records import (
@@ -22,10 +23,6 @@ from qcportal.models.records import (
     ResultRecord,
 )
 
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 from typing_extensions import Literal
 
 from openff.qcsubmit.results.results import (

--- a/openff/qcsubmit/results/filters.py
+++ b/openff/qcsubmit/results/filters.py
@@ -22,7 +22,6 @@ from qcportal.models.records import (
     RecordStatusEnum,
     ResultRecord,
 )
-
 from typing_extensions import Literal
 
 from openff.qcsubmit.results.results import (

--- a/openff/qcsubmit/tests/results/__init__.py
+++ b/openff/qcsubmit/tests/results/__init__.py
@@ -2,6 +2,7 @@ import copy
 
 import numpy
 from openff.toolkit.topology import Molecule
+from openff.units import unit
 from pydantic import BaseModel
 from qcelemental.models import DriverEnum
 from qcportal.models import (
@@ -14,11 +15,6 @@ from qcportal.models import (
 )
 from qcportal.models.records import RecordStatusEnum
 from qcportal.models.torsiondrive import TDKeywords
-
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 
 from openff.qcsubmit.results import (
     BasicResult,

--- a/openff/qcsubmit/tests/results/conftest.py
+++ b/openff/qcsubmit/tests/results/conftest.py
@@ -1,11 +1,7 @@
 import numpy as np
 import pytest
 from openff.toolkit.topology import Molecule
-
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
+from openff.units import unit
 
 from openff.qcsubmit.results import (
     BasicResultCollection,

--- a/openff/qcsubmit/tests/results/test_caching.py
+++ b/openff/qcsubmit/tests/results/test_caching.py
@@ -122,7 +122,7 @@ def test_record_to_molecule(
         raise RuntimeError()
 
     assert numpy.allclose(
-        molecule.conformers[0].value_in_unit(unit.bohr),
+        molecule.conformers[0].m_as(unit.bohr),
         expected_qc_molecule.geometry.reshape((molecule.n_atoms, 3))
     )
 
@@ -164,7 +164,7 @@ def test_cached_query_torsion_drive_results(public_client):
     for grid_id, conformer in zip(molecule.properties["grid_ids"], molecule.conformers):
 
         assert numpy.allclose(
-            conformer.value_in_unit(unit.bohr),
+            conformer.m_as(unit.bohr),
             expected_qc_molecules[grid_id].geometry.reshape((molecule.n_atoms, 3))
         )
 

--- a/openff/qcsubmit/tests/results/test_caching.py
+++ b/openff/qcsubmit/tests/results/test_caching.py
@@ -4,12 +4,8 @@ import numpy
 import pytest
 import requests_mock
 from openff.toolkit.topology import Molecule
+from openff.units import unit
 from qcportal.models import ObjectId, OptimizationRecord, ResultRecord
-
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 
 from openff.qcsubmit.results import BasicResult, OptimizationResult, TorsionDriveResult
 from openff.qcsubmit.results.caching import (

--- a/openff/qcsubmit/tests/results/test_filters.py
+++ b/openff/qcsubmit/tests/results/test_filters.py
@@ -3,15 +3,11 @@ import logging
 import numpy
 import pytest
 from openff.toolkit.topology import Molecule
+from openff.units import unit
 from pydantic import ValidationError
 from qcelemental.models import DriverEnum
 from qcportal.models import ObjectId, ResultRecord
 from qcportal.models.records import RecordStatusEnum
-
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 
 from openff.qcsubmit.results import (
     BasicResult,

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -6,6 +6,7 @@ import numpy
 import pytest
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.units import unit
 from pydantic import ValidationError
 from qcportal import FractalClient
 from qcportal.models import Molecule as QCMolecule
@@ -22,11 +23,6 @@ from qcportal.models.common_models import (
 )
 from qcportal.models.records import RecordStatusEnum
 from qcportal.models.torsiondrive import TDKeywords
-
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 
 from openff.qcsubmit.common_structures import QCSpec
 from openff.qcsubmit.exceptions import RecordTypeError

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -8,12 +8,8 @@ import numpy as np
 import pytest
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.units import unit
 from pydantic import ValidationError
-
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 
 from openff.qcsubmit.common_structures import MoleculeAttributes, QCSpec
 from openff.qcsubmit.constraints import Constraints, PositionConstraintSet

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -1364,7 +1364,10 @@ def test_basicdataset_add_molecules_conformers():
     for mol in dataset.molecules:
         assert butane.is_isomorphic_with(mol)
         for i in range(butane.n_conformers):
-            assert mol.conformers[i].flatten().tolist() == pytest.approx(butane.conformers[i].flatten().tolist())
+            assert (
+                mol.conformers[i].m_as(unit.angstrom)
+                == pytest.approx(butane.conformers[i].m_as(unit.angstrom))
+            )
 
 
 def test_basic_dataset_coverage_reporter():

--- a/openff/qcsubmit/tests/test_workflow_components.py
+++ b/openff/qcsubmit/tests/test_workflow_components.py
@@ -329,10 +329,7 @@ def test_rmsd_filter():
     """
     import copy
 
-    try:
-        from openmm import unit
-    except ImportError:
-        from simtk import unit
+    from openff.units import unit
 
     rmsd_filter = workflow_components.RMSDCutoffConformerFilter(cutoff=1)
     mol = Molecule.from_smiles("CCCC")

--- a/openff/qcsubmit/utils/smirnoff.py
+++ b/openff/qcsubmit/utils/smirnoff.py
@@ -211,7 +211,7 @@ def combine_openff_molecules(molecules: List[Molecule]) -> Molecule:
 
     master_mol = copy.deepcopy(molecules.pop(0))
     conformers = [
-        conformer.in_units_of(unit.angstrom) for conformer in master_mol.conformers
+        conformer.to(unit.angstrom) for conformer in master_mol.conformers
     ]
     master_mol._conformers = []
     index_map = {}
@@ -231,7 +231,7 @@ def combine_openff_molecules(molecules: List[Molecule]) -> Molecule:
             master_mol.add_bond(**bond_data)
         for i, conformer in enumerate(molecule.conformers):
             conformers[i] = numpy.vstack(
-                [conformers[i], conformer.in_units_of(unit.angstrom)]
+                [conformers[i], conformer.to(unit.angstrom)]
             )
 
     for conformer in conformers:

--- a/openff/qcsubmit/utils/smirnoff.py
+++ b/openff/qcsubmit/utils/smirnoff.py
@@ -4,15 +4,11 @@ from typing import Dict, Iterable, List, Tuple
 
 import numpy
 
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
-
 import networkx as nx
 import numpy as np
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.units import unit
 from tqdm import tqdm
 
 

--- a/openff/qcsubmit/utils/smirnoff.py
+++ b/openff/qcsubmit/utils/smirnoff.py
@@ -227,9 +227,7 @@ def combine_openff_molecules(molecules: List[Molecule]) -> Molecule:
             }
             master_mol.add_bond(**bond_data)
         for i, conformer in enumerate(molecule.conformers):
-            conformers[i] = numpy.vstack(
-                [conformers[i], conformer]
-            )
+            conformers[i] = numpy.vstack([conformers[i], conformer])
 
     for conformer in conformers:
         master_mol.add_conformer(conformer)

--- a/openff/qcsubmit/utils/smirnoff.py
+++ b/openff/qcsubmit/utils/smirnoff.py
@@ -206,13 +206,11 @@ def split_openff_molecule(molecule: Molecule) -> List[Molecule]:
 
 def combine_openff_molecules(molecules: List[Molecule]) -> Molecule:
     """
-    For a given set of openff molecules combine them into a single structure assuming the conformers are compatible..
+    Combine a list of molecules with equal numbers of conformers into one.
     """
 
     master_mol = copy.deepcopy(molecules.pop(0))
-    conformers = [
-        conformer.to(unit.angstrom) for conformer in master_mol.conformers
-    ]
+    conformers = [*master_mol.conformers]
     master_mol._conformers = []
     index_map = {}
     for molecule in molecules:
@@ -231,10 +229,10 @@ def combine_openff_molecules(molecules: List[Molecule]) -> Molecule:
             master_mol.add_bond(**bond_data)
         for i, conformer in enumerate(molecule.conformers):
             conformers[i] = numpy.vstack(
-                [conformers[i], conformer.to(unit.angstrom)]
+                [conformers[i], conformer]
             )
 
     for conformer in conformers:
-        master_mol.add_conformer(conformer * unit.angstrom)
+        master_mol.add_conformer(conformer)
 
     return master_mol

--- a/openff/qcsubmit/utils/smirnoff.py
+++ b/openff/qcsubmit/utils/smirnoff.py
@@ -2,9 +2,8 @@ import copy
 from collections import defaultdict
 from typing import Dict, Iterable, List, Tuple
 
-import numpy
-
 import networkx as nx
+import numpy
 import numpy as np
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField

--- a/openff/qcsubmit/workflow_components/filters.py
+++ b/openff/qcsubmit/workflow_components/filters.py
@@ -13,7 +13,6 @@ from openff.toolkit.utils import (
 from openff.units import unit
 from pydantic import Field, root_validator, validator
 from rdkit.Chem.rdMolAlign import AlignMol
-
 from typing_extensions import Literal
 
 from openff.qcsubmit.common_structures import ComponentProperties

--- a/openff/qcsubmit/workflow_components/filters.py
+++ b/openff/qcsubmit/workflow_components/filters.py
@@ -10,13 +10,10 @@ from openff.toolkit.utils import (
     RDKitToolkitWrapper,
     ToolkitRegistry,
 )
+from openff.units import unit
 from pydantic import Field, root_validator, validator
 from rdkit.Chem.rdMolAlign import AlignMol
 
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 from typing_extensions import Literal
 
 from openff.qcsubmit.common_structures import ComponentProperties

--- a/openff/qcsubmit/workflow_components/filters.py
+++ b/openff/qcsubmit/workflow_components/filters.py
@@ -763,7 +763,7 @@ class ChargeFilter(ToolkitValidator, CustomWorkflowComponent):
         result = self._create_result(toolkit_registry=toolkit_registry)
 
         for molecule in molecules:
-            total_charge = molecule.total_charge.value_in_unit(unit.elementary_charge)
+            total_charge = molecule.total_charge.m_as(unit.elementary_charge)
 
             if (
                 self.charges_to_include is not None

--- a/openff/qcsubmit/workflow_components/utils.py
+++ b/openff/qcsubmit/workflow_components/utils.py
@@ -4,8 +4,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import openff.toolkit.topology as off
-from openff.units import unit
 import tqdm
+from openff.units import unit
 from pydantic import Field, validator
 
 from openff.qcsubmit.common_structures import DatasetConfig, ResultsConfig

--- a/openff/qcsubmit/workflow_components/utils.py
+++ b/openff/qcsubmit/workflow_components/utils.py
@@ -4,13 +4,9 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import openff.toolkit.topology as off
+from openff.units import unit
 import tqdm
 from pydantic import Field, validator
-
-try:
-    from openmm import unit
-except ImportError:
-    from simtk import unit
 
 from openff.qcsubmit.common_structures import DatasetConfig, ResultsConfig
 from openff.qcsubmit.validators import check_environments

--- a/openff/qcsubmit/workflow_components/utils.py
+++ b/openff/qcsubmit/workflow_components/utils.py
@@ -744,11 +744,9 @@ class ComponentResult:
                 for conformer in molecule.conformers:
                     new_conformer = np.zeros((molecule.n_atoms, 3))
                     for i in range(molecule.n_atoms):
-                        new_conformer[i] = conformer[mapping[i]].value_in_unit(
-                            unit.angstrom
-                        )
+                        new_conformer[i] = conformer[mapping[i]].m_as(unit.angstrom)
 
-                    new_conf = unit.Quantity(value=new_conformer, unit=unit.angstrom)
+                    new_conf = unit.Quantity(new_conformer, unit.angstrom)
 
                     # check if the conformer is already on the molecule
                     for old_conformer in self._molecules[molecule_hash].conformers:


### PR DESCRIPTION
## Description

Update QCSubmit to work with the OpenFF Toolkit 0.11+

Supersedes #203 

## Todos
- [x] Pin Toolkit >= 0.11 in environments

Test failures (running locally on my machine):
  - [x] Many test failures due to moving from OpenMM units to OpenFF units in locally executed code that were fixed with simple find+replace
  - [x]  Several test failures due to https://github.com/openforcefield/openff-toolkit/issues/1416 that are fixed in https://github.com/openforcefield/openff-toolkit/pull/1417
  - [x] A usage of `pytest.approx` that needed updating with the new units package
  - [x] Manual unit handling in `combine_openff_molecules` around `np.vstack()` that is no longer necessary with OpenFF units
  - [x] A number of tests from QCEngine's lack of support for Toolkit 0.11 (https://github.com/MolSSI/QCEngine/pull/378)

## Status
- [x] Requires https://github.com/MolSSI/QCEngine/pull/378 in a release on conda forge
- [x] Requires https://github.com/openforcefield/openff-toolkit/pull/1417 in a release on conda forge
- [x] Ready to go