### PR TITLE
Improve compatibility with non-Psi4 engines

### DIFF
--- a/devtools/conda-envs/docs.yaml
+++ b/devtools/conda-envs/docs.yaml
@@ -24,7 +24,7 @@ dependencies:
 #  - rdkit                MOCKED
   - pydantic
   - pyyaml
-  - qcportal
+  - qcportal >=0.15
   - torsiondrive
   - basis_set_exchange
   - typing-extensions

--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -486,10 +486,9 @@ class QCSpec(ResultsConfig):
             "torchani": {None: ani_methods},
             "xtb": {None: xtb_methods},
             "rdkit": {None: rdkit_methods},
-            "psi4": {},
         }
 
-        if program.lower() != "psi4":
+        if program.lower() in settings:
             # make sure PCM is not set
             if implicit_solvent is not None:
                 raise QCSpecificationError(

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -1738,7 +1738,6 @@ def test_remove_qcspec():
 
 
 @pytest.mark.parametrize("qc_spec", [
-    pytest.param(({"method": "hf", "basis": "DZVP", "program": "bad_program"}, True), id="Bad method Error"),
     pytest.param(({"method": "gfn1xtb", "basis": "bad", "program": "xtb"}, True), id="Bad basis xtb Error"),
     pytest.param(({"method": "ani1x", "basis": "ani1x", "program": "torchani"}, True), id="Bad basis torchani Error"),
     pytest.param(({"method": "parsley", "basis": "smirnoff", "program": "openmm"}, True), id="Bad method smirnoff Error"),


### PR DESCRIPTION
## Description
The current logic makes it difficult to use QC packages supported by QCEngine besides Psi4. This updates the logic to _not_ assume that the `program` argument is in the `settings` dictionary.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go