### PR TITLE
Update `get_torsion` for OpenFF Toolkit 0.12

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -15,7 +15,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - codecov
   - requests-mock
 
   - qcengine >=0.25
@@ -28,18 +27,13 @@ dependencies:
 
   # openmmforcefields brings in the full toolkit; if that is ever re-packaged
   # this should be changed to openff-toolkit-base
-  - openff-toolkit >= 0.11.3
-  # argcomplete (brought in via BSE) pulls down totally incorrect builds of `importlib_metadata`,
-  - importlib_metadata >=4
-  - importlib-metadata >=4
-  - rdkit
+  - openff-toolkit >= 0.12
   - pydantic
   - pyyaml
   - qcportal>=0.15.7
   - torsiondrive
   - basis_set_exchange
   - typing-extensions
-  - cachetools
   - h5py>=3.6.0
 
   # Optional

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -115,17 +115,19 @@ def get_torsion(bond: off.Bond) -> Tuple[int, int, int, int]:
         If there is more than one possible combination of atoms the heaviest set are selected to be restrained.
     """
 
-    atoms = [bond.atom1, bond.atom2]
-    terminal_atoms = {}
+    atoms: List[off.Atom] = [bond.atom1, bond.atom2]
+    terminal_atoms: Dict[off.Atom, off.atom] = dict()
 
     for atom in atoms:
         for neighbour in atom.bonded_atoms:
             if neighbour not in atoms:
-                if (
-                    neighbour.atomic_number
-                    > terminal_atoms.get(atom, off.Atom(0, 0, False)).atomic_number
-                ):
+                # If we have not seen any possible terminal atoms for this atom, add the neighbour
+                if atom not in terminal_atoms:
                     terminal_atoms[atom] = neighbour
+                # If the neighbour is heavier than the current terminal atom, replace it
+                if neighbour.atomic_number > terminal_atoms.get(atom).atomic_number:
+                    terminal_atoms[atom] = neighbour
+
     # build out the torsion
     return tuple(
         [

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -125,7 +125,7 @@ def get_torsion(bond: off.Bond) -> Tuple[int, int, int, int]:
                 if atom not in terminal_atoms:
                     terminal_atoms[atom] = neighbour
                 # If the neighbour is heavier than the current terminal atom, replace it
-                if neighbour.atomic_number > terminal_atoms.get(atom).atomic_number:
+                elif neighbour.atomic_number > terminal_atoms.get(atom).atomic_number:
                     terminal_atoms[atom] = neighbour
 
     # build out the torsion


### PR DESCRIPTION
## Description
Resolves #209

The function `get_torsion` included in its logic some empheral `Atom` objects with atomic numbers of 0, which are now forbidden. I've changed the logic to avoid needing to do this. The behavior is the same as far as I understand the function to work.

I've also taken the liberty of updating some outdated bits in the test environment.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Fix #209

## Status
- [ ] Ready to go