### PR TITLE
Task export for torsiondrive datasets

### DIFF
--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -21,7 +21,12 @@ import tqdm
 from openff.toolkit import topology as off
 from pydantic import Field, constr, validator
 from qcelemental.models import AtomicInput, OptimizationInput
-from qcelemental.models.procedures import QCInputSpecification
+from qcelemental.models.procedures import (
+    OptimizationSpecification,
+    QCInputSpecification,
+    TDKeywords,
+    TorsionDriveInput,
+)
 from qcportal.models.common_models import DriverEnum, QCSpecification
 from typing_extensions import Literal
 
@@ -1620,7 +1625,45 @@ class TorsiondriveDataset(OptimizationDataset):
         except KeyError:
             return False
 
-    def to_tasks(self) -> Dict[str, List[OptimizationInput]]:
+    def to_tasks(self) -> Dict[str, List[TorsionDriveInput]]:
         """Build a list of QCEngine procedure tasks which correspond to this dataset."""
 
-        raise NotImplementedError()
+        data = defaultdict(list)
+        opt_program = self.optimization_procedure.program.lower()
+        opt_spec_keywords = self.optimization_procedure.dict(exclude={"program"})
+        for spec in self.qc_specifications.values():
+            qc_model = spec.qc_model
+            qc_keywords = spec.qc_keywords
+            qc_spec = QCInputSpecification(
+                driver=self.driver, model=qc_model, keywords=qc_keywords
+            )
+            opt_spec_keywords["program"] = spec.program.lower()
+            opt_spec = OptimizationSpecification(
+                procedure=opt_program, keywords=opt_spec_keywords
+            )
+
+            for index, entry in self.dataset.items():
+                index, _ = self._clean_index(index=index)
+
+                data["torsiondrive"].append(
+                    TorsionDriveInput(
+                        # no id field so hide in extras
+                        extras={"name": index},
+                        # for each setting check scan specific then dataset wide settings
+                        keywords=TDKeywords(
+                            dihedrals=entry.dihedrals,
+                            grid_spacing=entry.keywords.grid_spacing
+                            or self.grid_spacing,
+                            dihedral_ranges=entry.keywords.dihedral_ranges
+                            or self.dihedral_ranges,
+                            energy_decrease_thresh=entry.keywords.energy_decrease_thresh
+                            or self.energy_decrease_thresh,
+                            energy_upper_limit=entry.keywords.energy_upper_limit
+                            or self.energy_upper_limit,
+                        ),
+                        input_specification=qc_spec,
+                        initial_molecule=entry.initial_molecules,
+                        optimization_spec=opt_spec,
+                    )
+                )
+        return data

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -1915,7 +1915,8 @@ def test_torsiondrivedataset_torsion_indices():
 
 @pytest.mark.parametrize("dataset_type, program", [
     pytest.param(BasicDataset, "psi4", id="basic"),
-    pytest.param(OptimizationDataset, "geometric", id="optimization")
+    pytest.param(OptimizationDataset, "geometric", id="optimization"),
+    pytest.param(TorsiondriveDataset, "torsiondrive", id="Torsiondrive")
 ])
 def test_dataset_tasks(dataset_type, program):
     """


### PR DESCRIPTION
## Description
This PR implements the `to_tasks` method for the`TorsiondriveDataset`  which creates a set of equivalent QCEngine tasks which can be run locally rather than via QCFractal. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go