### PR TITLE
Make loading datasets skip over corrupt entries with invalid CMILES

### DIFF
--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -3,6 +3,7 @@ A module which contains convenience classes for referencing, retrieving and filt
 results from a QCFractal instance.
 """
 import abc
+import warnings
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
@@ -467,6 +468,10 @@ class OptimizationResultCollection(_BaseResultCollection):
                             allow_undefined_stereo=True,
                         )
                     except ValueError:
+                        warnings.warn(
+                            f"Skipping entry {entry.name} with invalid CMILES {entry.attributes['canonical_isomeric_explicit_hydrogen_mapped_smiles']}",
+                            UserWarning,
+                        )
                         continue
                     inchi_key = mol.to_inchikey(fixed_hydrogens=True)
 

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -441,26 +441,36 @@ class OptimizationResultCollection(_BaseResultCollection):
             client = dataset.client
             query = dataset.query(spec_name)
 
-            result_records[client.address].update(
-                {
-                    query[entry.name].id: OptimizationResult(
-                        record_id=query[entry.name].id,
-                        cmiles=entry.attributes[
-                            "canonical_isomeric_explicit_hydrogen_mapped_smiles"
-                        ],
-                        inchi_key=entry.attributes.get("fixed_hydrogen_inchi_key")
-                        or Molecule.from_mapped_smiles(
-                            entry.attributes[
-                                "canonical_isomeric_explicit_hydrogen_mapped_smiles"
-                            ],
-                            allow_undefined_stereo=True,
-                        ).to_inchikey(fixed_hydrogens=True),
-                    )
-                    for entry in dataset.data.records.values()
-                    if entry.name in query
-                    and query[entry.name].status.value.upper() == "COMPLETE"
-                }
-            )
+            for entry in dataset.data.records.values():
+                if not((entry.name in query) and
+                       (query[entry.name].status.value.upper() == "COMPLETE")):
+                    continue
+                inchi_key = entry.attributes.get("fixed_hydrogen_inchi_key")
+                if inchi_key is None:
+                    try:
+                        mol = Molecule.from_mapped_smiles(
+                                entry.attributes[
+                                    "canonical_isomeric_explicit_hydrogen_mapped_smiles"
+                                ],
+                                allow_undefined_stereo=True,
+                            )
+                    except ValueError:
+                        continue
+                    inchi_key = mol.to_inchikey(fixed_hydrogens=True)
+
+                result_records[client.address][query[entry.name].id] = OptimizationResult(
+                    record_id=query[entry.name].id,
+                    cmiles=entry.attributes[
+                        "canonical_isomeric_explicit_hydrogen_mapped_smiles"
+                    ],
+                    inchi_key=inchi_key
+                )
+
+            #result_records[client.address].update(
+            #    {
+            #        :
+            #    }
+            #)
 
         return cls(
             entries={

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -442,35 +442,39 @@ class OptimizationResultCollection(_BaseResultCollection):
             query = dataset.query(spec_name)
 
             for entry in dataset.data.records.values():
-                if not((entry.name in query) and
-                       (query[entry.name].status.value.upper() == "COMPLETE")):
+                if not (
+                    (entry.name in query)
+                    and (query[entry.name].status.value.upper() == "COMPLETE")
+                ):
                     continue
                 inchi_key = entry.attributes.get("fixed_hydrogen_inchi_key")
                 if inchi_key is None:
                     try:
                         mol = Molecule.from_mapped_smiles(
-                                entry.attributes[
-                                    "canonical_isomeric_explicit_hydrogen_mapped_smiles"
-                                ],
-                                allow_undefined_stereo=True,
-                            )
+                            entry.attributes[
+                                "canonical_isomeric_explicit_hydrogen_mapped_smiles"
+                            ],
+                            allow_undefined_stereo=True,
+                        )
                     except ValueError:
                         continue
                     inchi_key = mol.to_inchikey(fixed_hydrogens=True)
 
-                result_records[client.address][query[entry.name].id] = OptimizationResult(
+                result_records[client.address][
+                    query[entry.name].id
+                ] = OptimizationResult(
                     record_id=query[entry.name].id,
                     cmiles=entry.attributes[
                         "canonical_isomeric_explicit_hydrogen_mapped_smiles"
                     ],
-                    inchi_key=inchi_key
+                    inchi_key=inchi_key,
                 )
 
-            #result_records[client.address].update(
+            # result_records[client.address].update(
             #    {
             #        :
             #    }
-            #)
+            # )
 
         return cls(
             entries={

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -480,12 +480,6 @@ class OptimizationResultCollection(_BaseResultCollection):
                     inchi_key=inchi_key,
                 )
 
-            # result_records[client.address].update(
-            #    {
-            #        :
-            #    }
-            # )
-
         return cls(
             entries={
                 address: [*entries.values()]

--- a/openff/qcsubmit/tests/results/conftest.py
+++ b/openff/qcsubmit/tests/results/conftest.py
@@ -1,7 +1,12 @@
 import numpy as np
+import pandas as pd
 import pytest
 from openff.toolkit.topology import Molecule
 from openff.units import unit
+from qcportal import FractalClient
+from qcportal.collections import OptimizationDataset
+from qcportal.collections.optimization_dataset import OptEntry
+from qcportal.models.records import OptimizationRecord
 
 from openff.qcsubmit.results import (
     BasicResultCollection,
@@ -180,3 +185,66 @@ def torsion_drive_result_collection(monkeypatch) -> TorsionDriveResultCollection
     }
 
     return mock_torsion_drive_result_collection(smiles, monkeypatch)
+
+
+@pytest.fixture()
+def optimization_dataset_invalid_cmiles(monkeypatch, fractal_compute_server):
+    """Creates a mocked qcportal optimization dataset with one normal and one invalid cmiles record."""
+    client = FractalClient(fractal_compute_server)
+    # Fake the records in the dataset with missing data
+    data = {
+        "GNT-00284-0": OptEntry(
+            name="GNT-00284-0",
+            initial_molecule="33240545",
+            additional_keywords={},
+            attributes={
+                "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[F:1][c:2]1[c:3]([H:32])[c:4]([H:33])[c:5]([H:34])[c:6]([F:7])[c:8]1[C:9]1=[N:12][N:13]2[C:14](=[C:15]([H:37])[N:16]=[C:17]2[N:18]([c:19]2[c:20]([H:39])[nH+:21][c:22]([H:40])[c:23]([H:41])[c:24]2[N:25]2[C:26]([H:42])([H:43])[C@:30]([NH+:31]([H:51])[H:52])([H:50])[C:29]([H:48])([H:49])[C:28]([H:46])([H:47])[C:27]2([H:44])[H:45])[H:38])[C:11]([H:36])=[C:10]1[H:35]",
+                "molecular_formula": "C22H21F2N7",
+                "standard_inchi": "InChI=1S/C22H21F2N7/c23-16-4-1-5-17(24)21(16)18-7-6-15-11-27-22(31(15)29-18)28-19-12-26-9-8-20(19)30-10-2-3-14(25)13-30/h1,4-9,11-12,14H,2-3,10,13,25H2,(H,27,28)/p+2/t14-/m0/s1",
+                "inchi_key": "MLPJIYXHHVPOPK-AWEZNQCLSA-P",
+            },
+            object_map={"default": "1"},
+        ),
+        "BRI-01356-0": OptEntry(
+            name="BRI-01356-0",
+            initial_molecule="33222549",
+            additional_keywords={},
+            attributes={
+                "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[N:1]([C:2](=[O:3])[c:4]1[c:5]([H:26])[c:6]([H:27])[c:7]([N:8]([C:9](=[O:10])[C:11]([N:12]2[C:13]([H:31])([H:32])[C:14]([H:33])([H:34])[C:15]([N:18]([C:19]([O:20][H:41])=[O:21])[H:40])([H:35])[C:16]([H:36])([H:37])[C:17]2([H:38])[H:39])([H:29])[H:30])[H:28])[c:22]([H:42])[c:23]1[H:43])([H:24])[H:25]",
+                "molecular_formula": "C15H20N4O4",
+                "standard_inchi": "InChI=1S/C15H20N4O4/c16-14(21)10-1-3-11(4-2-10)17-13(20)9-19-7-5-12(6-8-19)18-15(22)23/h1-4,12,18H,5-9H2,(H2,16,21)(H,17,20)(H,22,23)",
+                "inchi_key": "AZHQPEOBSZLCKD-UHFFFAOYSA-N",
+            },
+            object_map={"default": "2"},
+        ),
+    }
+    dataset = OptimizationDataset(
+        name="invalid-collection", client=client, records=data
+    )
+
+    # now mock the query function which is called when processing the results
+    def query(spec_name):
+        mock_spec = {
+            "driver": "gradient",
+            "method": "B3LYP-D3BJ",
+            "basis": "DZVP",
+            "program": "psi4",
+        }
+        results = {
+            opt.name: OptimizationRecord(
+                id=opt.object_map["default"],
+                procedure="optimization",
+                program="geometric",
+                version=1,
+                status="COMPLETE",
+                initial_molecule="1",
+                qc_spec=mock_spec,
+            )
+            for opt in data.values()
+        }
+        return pd.Series(results)
+
+    # mock the status of the records
+    monkeypatch.setattr(dataset, "query", query)
+
+    return dataset

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -535,9 +535,10 @@ def test_from_datasets_invalid_cmiles(optimization_dataset_invalid_cmiles):
     """Test creating results from collections with invalid records."""
 
     # this mocked dataset has one valid and one invalid record
-    result = OptimizationResultCollection.from_datasets(
-        datasets=[optimization_dataset_invalid_cmiles], spec_name="default"
-    )
+    with pytest.warns(UserWarning, match="Skipping entry GNT-00284-0 with invalid CMILES"):
+        result = OptimizationResultCollection.from_datasets(
+            datasets=[optimization_dataset_invalid_cmiles], spec_name="default"
+        )
     # make sure the invalid record is dropped
     assert result.n_results == 1
     # make sure only record id 2 is present this is the valid record

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -529,3 +529,17 @@ def test_torsion_smirnoff_coverage(public_client, monkeypatch):
     assert {*coverage["Angles"].values()} == {3}
 
     assert {*coverage["ProperTorsions"].values()} == {1, 3}
+
+
+def test_from_datasets_invalid_cmiles(optimization_dataset_invalid_cmiles):
+    """Test creating results from collections with invalid records."""
+
+    # this mocked dataset has one valid and one invalid record
+    result = OptimizationResultCollection.from_datasets(
+        datasets=[optimization_dataset_invalid_cmiles], spec_name="default"
+    )
+    # make sure the invalid record is dropped
+    assert result.n_results == 1
+    # make sure only record id 2 is present this is the valid record
+    record = list(result.entries.values())[0][0]
+    assert record.record_id == "2"

--- a/openff/qcsubmit/tests/results/test_results.py
+++ b/openff/qcsubmit/tests/results/test_results.py
@@ -535,7 +535,9 @@ def test_from_datasets_invalid_cmiles(optimization_dataset_invalid_cmiles):
     """Test creating results from collections with invalid records."""
 
     # this mocked dataset has one valid and one invalid record
-    with pytest.warns(UserWarning, match="Skipping entry GNT-00284-0 with invalid CMILES"):
+    with pytest.warns(
+        UserWarning, match="Skipping entry GNT-00284-0 with invalid CMILES"
+    ):
         result = OptimizationResultCollection.from_datasets(
             datasets=[optimization_dataset_invalid_cmiles], spec_name="default"
         )


### PR DESCRIPTION
## Todos

  - [x] Fix #216
  - [x] Add tests
  - [ ] ~(optional) Make both backends give the same number of molecules when loading the industry dataset.~ (these changes need to go into the OpenFF Toolkit)
  - [x] Emit a warning with a dataset entry is skipped for having an invalid CMILES. 
  - [x] ~Open issue in OpenFF Toolkit about making RDKitToolkitWrapper be strict about mapped SMILES with implicit Hs~ https://github.com/openforcefield/openff-toolkit/issues/1696
  - [x] ~Open issue in OpenFF Toolkit about preventing such SMILES from being created again.~ https://github.com/openforcefield/openff-toolkit/issues/1697
  - [x] ~Open issue in qca-dataset-submission about the corrupt entries (not planned for immediate action, but as a place for people to collect requests for the creation of a cleaned dataset)~ https://github.com/openforcefield/qca-dataset-submission/issues/327

## Status
- [x] Ready to go