### PR TITLE
Update QCSubmit for removal of ChemicalEnvironment class in OFFTK >0.14.1

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   # openmmforcefields brings in the full toolkit; if that is ever re-packaged
   # this should be changed to openff-toolkit-base
-  - openff-toolkit == 0.14.0
+  - openff-toolkit >= 0.14.0
   - openff-units >=0.2.1
   - pydantic =1
   - pyyaml

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -28,7 +28,7 @@ dependencies:
 
   ### Core dependencies.
 
-  - openff-toolkit-base == 0.14.0
+  - openff-toolkit-base >= 0.14.0
   - openff-units >=0.2.1
   - rdkit
   - pydantic =1

--- a/openff/qcsubmit/tests/test_workflow_components.py
+++ b/openff/qcsubmit/tests/test_workflow_components.py
@@ -901,6 +901,14 @@ def test_smarts_filter_validator():
         # good smarts with no tagged atoms.
         workflow_components.SmartsFilter(allowed_substructures=["[C]=[C]"])
 
+    from openff.toolkit.utils import ToolkitRegistry
+    from openff.toolkit.utils.toolkit_registry import _toolkit_registry_manager
+
+    # this test is the same as above, but without any toolkit available
+    with pytest.raises(ValueError):
+        with _toolkit_registry_manager(ToolkitRegistry()):
+            workflow_components.SmartsFilter(allowed_substructures=["[C]=[C]"])
+
     # a good search string
     smart_filter = workflow_components.SmartsFilter(
         allowed_substructures=["[C:1]=[C:2]"]

--- a/openff/qcsubmit/tests/test_workflow_components.py
+++ b/openff/qcsubmit/tests/test_workflow_components.py
@@ -877,7 +877,7 @@ def test_smarts_filter_validator():
     Make sure the validator is checking the allowed and filtered fields have valid smirks strings.
     """
 
-    from openff.toolkit.typing.chemistry import SMIRKSParsingError
+    from openff.toolkit.utils.exceptions import SMIRKSParsingError
 
     with pytest.raises(ValidationError):
         workflow_components.SmartsFilter(

--- a/openff/qcsubmit/validators.py
+++ b/openff/qcsubmit/validators.py
@@ -296,7 +296,11 @@ def check_environments(environment: str) -> str:
         # capability "find_smarts_matches" for args...' it would be nice for
         # chemical_environment_matches to raise a more specific exception, but
         # it just raises a ValueError
-        if 'capability "find_smarts_matches"' not in str(e):
+        s = str(e)
+        if (
+            'capability "find_smarts_matches"' not in s
+            or "Available toolkits are: []" in s
+        ):
             raise e
 
     # we've either already returned successfully, raised an unrelated

--- a/openff/qcsubmit/validators.py
+++ b/openff/qcsubmit/validators.py
@@ -5,11 +5,9 @@ import re
 from typing import List, Tuple, Union
 
 import qcelemental as qcel
+from openff.toolkit import Molecule
 from openff.toolkit import topology as off
-from openff.toolkit.typing.chemistry.environment import (
-    ChemicalEnvironment,
-    SMIRKSParsingError,
-)
+from openff.toolkit.utils.exceptions import SMIRKSParsingError
 
 from openff.qcsubmit.constraints import Constraints
 from openff.qcsubmit.exceptions import (
@@ -288,14 +286,22 @@ def check_environments(environment: str) -> str:
     """
 
     # try and make a new chemical environment checking for parse errors
-    _ = ChemicalEnvironment(smirks=environment)
+    try:
+        _ = Molecule().chemical_environment_matches(environment)
+        # check for numeric tags in the environment
+        if re.search(":[0-9]]+", environment) is not None:
+            return environment
+    except ValueError as e:
+        # only catch an error like 'No registered toolkits can provide the
+        # capability "find_smarts_matches" for args...' it would be nice for
+        # chemical_environment_matches to raise a more specific exception, but
+        # it just raises a ValueError
+        if 'capability "find_smarts_matches"' not in str(e):
+            raise e
 
-    # check for numeric tags in the environment
-    if re.search(":[0-9]]+", environment) is not None:
-        return environment
-
-    else:
-        raise SMIRKSParsingError(
-            "The smarts pattern passed had no tagged atoms please tag the atoms in the "
-            "substructure you wish to include/exclude."
-        )
+    # we've either already returned successfully, raised an unrelated
+    # exception, or failed to parse the smirks
+    raise SMIRKSParsingError(
+        "The smarts pattern passed had no tagged atoms please tag the atoms in the "
+        "substructure you wish to include/exclude."
+    )


### PR DESCRIPTION
## Description
[openff-toolkit 0.14.1](https://docs.openforcefield.org/projects/toolkit/en/stable/releasehistory.html#api-breaking-changes) removed the deprecated ChemicalEnvironment class and its associated module. We only used this in one place (plus a re-export of an exception type). This PR cleans up that one call site as suggested by @j-wags.

## Questions
- [ ] Do we want to keep `check_environments` at all?

## Status
- [ ] Ready to go