### PR TITLE
Expose ability to set OptimizationProtocols for for optimizations, torsiondrives

### DIFF
--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -20,7 +20,7 @@ import qcportal as ptl
 from openff.toolkit import topology as off
 from pydantic import Field, constr, validator
 from qcelemental.models import AtomicInput, OptimizationInput
-from qcelemental.models.procedures import QCInputSpecification
+from qcelemental.models.procedures import QCInputSpecification, OptimizationProtocols
 from qcportal import PortalClient, PortalRequestError
 from qcportal.optimization import OptimizationDatasetNewEntry, OptimizationSpecification
 from qcportal.singlepoint import (
@@ -907,7 +907,11 @@ class OptimizationDataset(BasicDataset):
         GeometricProcedure(),
         description="The optimization program and settings that should be used.",
     )
+    protocols: OptimizationProtocols = Field(
+            OptimizationProtocols(),
+            "Protocols regarding the manipulation of a Optimization output data.")
     dataset: Dict[str, OptimizationEntry] = {}
+
 
     @classmethod
     def _entry_class(cls) -> Type[OptimizationEntry]:
@@ -1031,6 +1035,7 @@ class OptimizationDataset(BasicDataset):
                 program=self.optimization_procedure.program,
                 qc_specification=qc_spec,
                 keywords=opt_kw,
+                protocols=self.protocols,
             )
 
         return ret
@@ -1099,6 +1104,7 @@ class OptimizationDataset(BasicDataset):
                             keywords=opt_spec,
                             input_specification=qc_spec,
                             initial_molecule=molecule,
+                            protocols=self.protocols
                         )
                     )
 
@@ -1248,6 +1254,7 @@ class TorsiondriveDataset(OptimizationDataset):
             spec = OptimizationSpecification(
                 program=self.optimization_procedure.program,
                 qc_specification=qc_spec,
+                protocols=self.protocols,
             )
             ret[spec_name] = TorsiondriveSpecification(
                 optimization_specification=spec,

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -909,7 +909,7 @@ class OptimizationDataset(BasicDataset):
     )
     protocols: OptimizationProtocols = Field(
         OptimizationProtocols(),
-        "Protocols regarding the manipulation of a Optimization output data.",
+        description="Protocols regarding the manipulation of a Optimization output data.",
     )
     dataset: Dict[str, OptimizationEntry] = {}
 

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -20,7 +20,7 @@ import qcportal as ptl
 from openff.toolkit import topology as off
 from pydantic import Field, constr, validator
 from qcelemental.models import AtomicInput, OptimizationInput
-from qcelemental.models.procedures import QCInputSpecification, OptimizationProtocols
+from qcelemental.models.procedures import OptimizationProtocols, QCInputSpecification
 from qcportal import PortalClient, PortalRequestError
 from qcportal.optimization import OptimizationDatasetNewEntry, OptimizationSpecification
 from qcportal.singlepoint import (
@@ -908,10 +908,10 @@ class OptimizationDataset(BasicDataset):
         description="The optimization program and settings that should be used.",
     )
     protocols: OptimizationProtocols = Field(
-            OptimizationProtocols(),
-            "Protocols regarding the manipulation of a Optimization output data.")
+        OptimizationProtocols(),
+        "Protocols regarding the manipulation of a Optimization output data.",
+    )
     dataset: Dict[str, OptimizationEntry] = {}
-
 
     @classmethod
     def _entry_class(cls) -> Type[OptimizationEntry]:
@@ -1104,7 +1104,7 @@ class OptimizationDataset(BasicDataset):
                             keywords=opt_spec,
                             input_specification=qc_spec,
                             initial_molecule=molecule,
-                            protocols=self.protocols
+                            protocols=self.protocols,
                         )
                     )
 

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -909,7 +909,7 @@ class OptimizationDataset(BasicDataset):
     )
     protocols: OptimizationProtocols = Field(
         OptimizationProtocols(),
-        description="Protocols regarding the manipulation of a Optimization output data.",
+        description="Protocols regarding the manipulation of Optimization output data.",
     )
     dataset: Dict[str, OptimizationEntry] = {}
 

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -2622,13 +2622,13 @@ def test_optimizationdataset_protocols():
         description="XXXXXXXX",
     )
 
-    assert dataset.protocols.trajectory == 'all'
+    assert dataset.protocols.trajectory == "all"
 
     # change the protocol to only save gradient evaluations for final state
     dataset.protocols = OptimizationProtocols(trajectory="final")
 
-    assert dataset.protocols.trajectory == 'final'
-    
+    assert dataset.protocols.trajectory == "final"
+
 
 def test_torsiondrivedataset_torsion_indices():
     """

--- a/openff/qcsubmit/tests/test_datasets.py
+++ b/openff/qcsubmit/tests/test_datasets.py
@@ -10,6 +10,7 @@ from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from openff.units import unit
 from pydantic import ValidationError
+from qcelemental.models.procedures import OptimizationProtocols
 
 from openff.qcsubmit.common_structures import MoleculeAttributes, QCSpec
 from openff.qcsubmit.constraints import Constraints, PositionConstraintSet
@@ -2609,6 +2610,25 @@ def test_optimizationdataset_qc_spec():
     # make sure the driver was set back to gradient
     assert dataset.driver == "deferred"
 
+
+def test_optimizationdataset_protocols():
+    """
+    Test adding a non-default OptimizationProtocols to an OptimizationDataset.
+    """
+
+    dataset = OptimizationDataset(
+        dataset_name="Test dataset",
+        dataset_tagline="XXXXXXXX",
+        description="XXXXXXXX",
+    )
+
+    assert dataset.protocols.trajectory == 'all'
+
+    # change the protocol to only save gradient evaluations for final state
+    dataset.protocols = OptimizationProtocols(trajectory="final")
+
+    assert dataset.protocols.trajectory == 'final'
+    
 
 def test_torsiondrivedataset_torsion_indices():
     """

--- a/openff/qcsubmit/tests/test_submissions.py
+++ b/openff/qcsubmit/tests/test_submissions.py
@@ -6,10 +6,10 @@ Here we use the qcfractal snowflake fixture to set up the database.
 
 import pytest
 from openff.toolkit.topology import Molecule
+from qcelemental.models.procedures import OptimizationProtocols
 from qcengine.testing import has_program
 from qcportal import PortalClient
 from qcportal.record_models import RecordStatusEnum
-from qcelemental.models.procedures import OptimizationProtocols
 
 from openff.qcsubmit import workflow_components
 from openff.qcsubmit.common_structures import MoleculeAttributes, PCMSettings
@@ -751,7 +751,7 @@ def test_optimization_submissions(fulltest_client, specification):
     dataset.metadata.long_description = None
 
     # only save final gradients, results
-    dataset.protocols = OptimizationProtocols(trajectory='initial_and_final')
+    dataset.protocols = OptimizationProtocols(trajectory="initial_and_final")
 
     with pytest.raises(DatasetInputError):
         dataset.submit(client=client)


### PR DESCRIPTION
## Description
[`OptimizationProtocols`](https://github.com/MolSSI/QCElemental/blob/1ef6b52adc4a18cfd6a2cfc1b56880daaeea3a44/qcelemental/models/procedures.py#L32-L48) allow users to e.g. only save gradients, wavefunctions for starting and final geometries of an optimization, reducing storage requirements for results. The changes here expose this functionality through QCSubmit, allowing users to set `OptimizationProtocols` settings other than the defaults if desired.

## Todos
  - [x] add tests

## Status
- [x] Ready to go
