### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Description
As it says on the tin. I wanted to set this up instead of manually updating the actions, and I wanted to do it in an atomic PR so I don't let it squander in a larger mess of my own creation.