### PR TITLE
Fix install instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,7 +30,7 @@ cd openff-qcsubmit
 Create a custom conda environment which contains the required dependencies and activate it:
 
 ```bash
-conda env create --name openff-qcsubmit --file devtools/conda-envs/meta.yaml
+conda env create --name openff-qcsubmit --file devtools/conda-envs/basic.yaml
 conda activate openff-qcsubmit
 ```
 


### PR DESCRIPTION
## Description
Our install docs were referring people to `devtools/conda-envs/meta.yaml`, which doesn't exist any more. We could either point them to `psi4.yaml` or `basic.yaml`. I think basic is better since it's more likely to be devs installing from source, and they'll know how to install psi4 afterwards if they need.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Fixes #271


## Status
- [ ] Ready to go