### PR TITLE
Pin QCPortal to 0.53

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -21,7 +21,7 @@ dependencies:
 
   - qcengine >=0.25
   - qcelemental >=0.25.1
-  - qcfractal >=0.52
+  - qcfractal =0.53
   - qcarchivetesting
   - qcportal
 

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -19,7 +19,7 @@ dependencies:
 
   - qcengine >=0.25
   - qcelemental >=0.25.1
-  - qcfractal >=0.52
+  - qcfractal =0.53
   - qcarchivetesting
   - qcportal
 


### PR DESCRIPTION
#275 is causing false negatives, so I'd like to pin this the upstream versions that are known to be compatible