### PR TITLE
Merge fetch_qc_torsiondrive example into retrieving-results

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -19,6 +19,8 @@ dependencies:
   - pytest-randomly
   - requests-mock
   - nbval
+  - plotly
+  - nglview
 
   - qcengine >=0.25
   - qcelemental >=0.25.1

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -17,6 +17,8 @@ dependencies:
   - pytest-xdist
   - requests-mock
   - nbval
+  - plotly
+  - nglview
 
   - qcengine >=0.25
   - qcelemental >=0.25.1

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,6 +15,7 @@ Releases are given with dates in DD-MM-YYYY format.
 ### Examples updated
 
 * [PR #283:] Run examples in CI, updates for QCPortal 0.54 and API changes in #141
+* [PR #285:] Add 2D torsion drive visualization
 
 ## 0.51.0 / 23-04-2024
 
@@ -130,6 +131,7 @@ For more information on this release, see https://github.com/openforcefield/open
 [PR #270:]: https://github.com/openforcefield/openff-qcsubmit/pull/270
 [PR #277:]: https://github.com/openforcefield/openff-qcsubmit/pull/277
 [PR #283:]: https://github.com/openforcefield/openff-qcsubmit/pull/283
+[PR #285:]: https://github.com/openforcefield/openff-qcsubmit/pull/285
 
 [@jthorton]: https://github.com/jthorton
 [@dotsdl]: https://github.com/dotsdl

--- a/examples/retrieving-results.ipynb
+++ b/examples/retrieving-results.ipynb
@@ -86,20 +86,42 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Many of the datasets we want to retrieve will be quite large, so we also define a\n",
+    "small helper function to print only a subset of their records:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from copy import deepcopy\n",
+    "\n",
+    "\n",
+    "def preview_dataset(ds, max_entries=5):\n",
+    "    ds = deepcopy(ds)\n",
+    "    for key, entry in ds.entries.items():\n",
+    "        ds.entries[key] = entry[:max_entries]\n",
+    "    print(ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "pycharm": {
      "name": "#%% md\n"
     }
    },
    "source": [
-    "Other servers can be accessed by providing the server's URI.\n",
-    "\n",
-    "We can then use this to generate our result collections:"
+    "We can then use our client to generate our result collections:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -112,26 +134,16 @@
      "text": [
       "entries={'https://api.qcarchive.molssi.org:443/': [BasicResult(type='basic', record_id=32651764, cmiles='[H:6][C:1]1([C:2]([C:4]([C:5]([C:3]1([H:10])[H:11])([H:14])[H:15])([H:12])[H:13])([H:8])[H:9])[H:7]', inchi_key='RGSFGYAAUTVSQA-UHFFFAOYNA-N'), BasicResult(type='basic', record_id=32651734, cmiles='[H:7][C:1]1([C:2]([C:4]([C:6]([C:5]([C:3]1([H:11])[H:12])([H:15])[H:16])([H:17])[H:18])([H:13])[H:14])([H:9])[H:10])[H:8]', inchi_key='XDTMQSROBMDMFD-UHFFFAOYNA-N'), BasicResult(type='basic', record_id=32651722, cmiles='[H:7][c:1]1[c:2]([c:4]([c:6]([c:5]([c:3]1[H:9])[H:11])[H:12])[H:10])[H:8]', inchi_key='UHOVQNZJYSORNB-UHFFFAOYNA-N'), BasicResult(type='basic', record_id=32651809, cmiles='[H:11][c:1]1[c:2]([c:4]([c:6]([c:5]([c:3]1[H:13])[H:15])[C:7]([H:16])([H:17])[C:8]([H:18])([H:19])[C:9]([H:20])([H:21])[O:10][H:22])[H:14])[H:12]', inchi_key='VAJVDSVGBWFCLW-UHFFFAOYNA-N'), BasicResult(type='basic', record_id=32651781, cmiles='[H:11][c:1]1[c:2]([c:4]([c:6]([c:5]([c:3]1[H:13])[H:15])[C:7]([H:16])([H:17])[C:8]([H:18])([H:19])[C:9]([H:20])([H:21])[O:10][H:22])[H:14])[H:12]', inchi_key='VAJVDSVGBWFCLW-UHFFFAOYNA-N')]} provenance={} type='BasicResultCollection'\n",
       "entries={'https://api.qcarchive.molssi.org:443/': [OptimizationResult(type='optimization', record_id=6091335, cmiles='[H:12][c:1]1[c:3]([c:4]([n:9][c:2]([n:8]1)[H:13])[N:10]2[C:6]([C:5]([C:7]2([H:18])[H:19])([H:14])[H:15])([H:16])[H:17])[Cl:11]', inchi_key='LQDSDOGLFAZWKS-UHFFFAOYNA-N'), OptimizationResult(type='optimization', record_id=6091336, cmiles='[H:14][c:1]1[c:3]([c:4]([n:11][c:2]([n:10]1)[H:15])[N:12]2[C:8]([C:6]([C:5]([C:7]([C:9]2([H:24])[H:25])([H:20])[H:21])([H:16])[H:17])([H:18])[H:19])([H:22])[H:23])[Cl:13]', inchi_key='VNZFCHDSOXTMKC-UHFFFAOYNA-N'), OptimizationResult(type='optimization', record_id=6091265, cmiles='[H:19][c:1]1[c:2]([c:4]([c:6]([c:5]([c:3]1[H:21])[N:15]2[C:9](=[O:16])[C:7]3=[C:8]([C:10]2=[O:17])[C:12]([C:14]([C:13]([C:11]3([H:23])[H:24])([H:27])[H:28])([H:29])[H:30])([H:25])[H:26])[F:18])[H:22])[H:20]', inchi_key='PINAKBXFAZUJBZ-UHFFFAOYNA-N'), OptimizationResult(type='optimization', record_id=6091454, cmiles='[H:17][c:1]1[c:2]([c:6]([c:10]([c:7]([c:3]1[H:19])[H:23])[C:13](=[O:15])[N:14]([H:26])[c:11]2[c:8]([c:4]([c:5]([c:9]([c:12]2[O:16][H:27])[H:25])[H:21])[H:20])[H:24])[H:22])[H:18]', inchi_key='UYKVWAQEMQDRGG-YHMJCDSINA-N'), OptimizationResult(type='optimization', record_id=6091455, cmiles='[H:17][c:1]1[c:2]([c:6]([c:10]([c:7]([c:3]1[H:19])[H:23])[C:13](=[O:15])[N:14]([H:26])[c:11]2[c:8]([c:4]([c:5]([c:9]([c:12]2[O:16][H:27])[H:25])[H:21])[H:20])[H:24])[H:22])[H:18]', inchi_key='UYKVWAQEMQDRGG-YHMJCDSINA-N')]} provenance={} type='OptimizationResultCollection'\n",
-      "entries={'https://api.qcarchive.molssi.org:443/': [TorsionDriveResult(type='torsion', record_id=21272367, cmiles='[H:16][c:1]1[c:2]([c:8]2[c:6]([c:3]([c:7]1[C:12]3=[C:10]([C:9](=[C:11]([O:15]3)[H:23])[H:21])[H:22])[H:18])[c:4]([n:13][c:5]([n:14]2)[H:20])[H:19])[H:17]', inchi_key='VQDKQTXZOFYKGJ-UHFFFAOYNA-N'), TorsionDriveResult(type='torsion', record_id=21272361, cmiles='[H:13][C:1]1=[C:2]([C:8](=[O:12])[N:11]([C:6](=[C:3]1[H:15])[C:7]2=[N:9][C:4](=[C:5]([N:10]2[H:18])[H:17])[H:16])[H:19])[H:14]', inchi_key='ZKHASKWVHRESCJ-FLKJISBTNA-N'), TorsionDriveResult(type='torsion', record_id=21272362, cmiles='[H:14][C:1]1=[C:2]([C:9](=[O:13])[N:11]([C:7](=[C:4]1[H:17])[C:8]2=[C:5]([C:3](=[C:6]([N:12]2[C:10]([H:20])([H:21])[H:22])[H:19])[H:16])[H:18])[H:23])[H:15]', inchi_key='HRRCFWLRKUBONR-WXRBYKJCNA-N'), TorsionDriveResult(type='torsion', record_id=21272422, cmiles='[H:13][C:1]1=[C:2]([C:9](=[O:11])[N:10]([C:7](=[C:4]1[H:16])[C:8]2=[C:5]([C:3](=[C:6]([O:12]2)[H:18])[H:15])[H:17])[H:19])[H:14]', inchi_key='GODUVOSSXJHPKL-KZFATGLANA-N'), TorsionDriveResult(type='torsion', record_id=21272428, cmiles='[H:13][C:1]1=[C:2]([C:9](=[O:11])[N:10]([C:7](=[C:4]1[H:16])[C:8]2=[C:5]([C:3](=[C:6]([S:12]2)[H:18])[H:15])[H:17])[H:19])[H:14]', inchi_key='OYXVCXRBUVWISS-KZFATGLANA-N')]} provenance={} type='TorsionDriveResultCollection'\n"
+      "entries={'https://api.qcarchive.molssi.org:443/': [TorsionDriveResult(type='torsion', record_id=104348544, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:25])[C@:18]([H:26])([C:19](=[O:20])[N:30]([H:35])[C@:31]([H:36])([C:32](=[O:33])[N:40]([H:42])[C:41]([H:43])([H:44])[H:45])[C:34]([H:37])([H:38])[H:39])[C:21]([H:27])([H:28])[C:22](=[O:23])[O:24][H:29])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='DFRSMLTYXUADOY-WMXHRXQGNA-N'), TorsionDriveResult(type='torsion', record_id=104348638, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:25])[C@:18]([H:26])([C:19](=[O:20])[N:31]([H:36])[C@:32]([H:37])([C:33](=[O:34])[N:41]([H:43])[C:42]([H:44])([H:45])[H:46])[C:35]([H:38])([H:39])[H:40])[C:21]([H:27])([H:28])[C:22](=[O:23])[N:24]([H:29])[H:30])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='KYQIKKWSTMGEQA-RIYGDZFYNA-N'), TorsionDriveResult(type='torsion', record_id=104348640, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:25])[C@:18]([H:26])([C:19](=[O:20])[N:29]([H:34])[C@:30]([H:35])([C:31](=[O:32])[N:39]([H:41])[C:40]([H:42])([H:43])[H:44])[C:33]([H:36])([H:37])[H:38])[C:21]([H:27])([H:28])[C:22](=[O:24])[O-:23])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='DFRSMLTYXUADOY-YXJNUYKJNA-M'), TorsionDriveResult(type='torsion', record_id=104350274, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:26])[C@:18]([H:27])([C:19](=[O:20])[N:33]([H:38])[C@:34]([H:39])([C:35](=[O:36])[N:43]([H:45])[C:44]([H:46])([H:47])[H:48])[C:37]([H:40])([H:41])[H:42])[C:21]([H:28])([H:29])[C:22]([H:30])([H:31])[C:23](=[O:24])[O:25][H:32])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='YVWAADJXUPAWMQ-MMEUZQAYNA-N'), TorsionDriveResult(type='torsion', record_id=104350994, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:26])[C@:18]([H:27])([C:19](=[O:20])[N:34]([H:39])[C@:35]([H:40])([C:36](=[O:37])[N:44]([H:46])[C:45]([H:47])([H:48])[H:49])[C:38]([H:41])([H:42])[H:43])[C:21]([H:28])([H:29])[C:22]([H:30])([H:31])[C:23](=[O:24])[N:25]([H:32])[H:33])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='WGYPYUBMHJDXLX-XZTNJZJKNA-N')]} provenance={} type='TorsionDriveResultCollection'\n"
      ]
     }
    ],
    "source": [
-    "from copy import deepcopy\n",
-    "\n",
     "from openff.qcsubmit.results import (\n",
     "    BasicResultCollection,\n",
     "    OptimizationResultCollection,\n",
     "    TorsionDriveResultCollection,\n",
     ")\n",
-    "\n",
-    "\n",
-    "def preview_dataset(ds, max_entries=5):\n",
-    "    ds = deepcopy(ds)\n",
-    "    for key, entry in ds.entries.items():\n",
-    "        ds.entries[key] = entry[:max_entries]\n",
-    "    print(ds)\n",
-    "\n",
     "\n",
     "# Pull down the energy result records from the 'OpenFF BCC Refit Study COH v1.0' dataset.\n",
     "energy_result_collection = BasicResultCollection.from_server(\n",
@@ -153,10 +165,10 @@
     ")\n",
     "preview_dataset(optimization_result_collection)\n",
     "\n",
-    "# Pull down the torsion drive records from the 'OpenFF Rowley Biaryl v1.0' dataset.\n",
+    "# Pull down the torsion drive records from the 'OpenFF Protein Capped 3-mer Backbones v1.0' dataset.\n",
     "torsion_drive_result_collection = TorsionDriveResultCollection.from_server(\n",
     "    client=qc_client,\n",
-    "    datasets=\"OpenFF Rowley Biaryl v1.0\",\n",
+    "    datasets=\"OpenFF Protein Capped 3-mer Backbones v1.0\",\n",
     "    spec_name=\"default\",\n",
     ")\n",
     "preview_dataset(torsion_drive_result_collection)"
@@ -182,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -200,8 +212,8 @@
       "N RESULTS:   2398\n",
       "N MOLECULES: 419\n",
       "===TORSION DRIVE RESULTS===\n",
-      "N RESULTS:   87\n",
-      "N MOLECULES: 87\n"
+      "N RESULTS:   23\n",
+      "N MOLECULES: 23\n"
      ]
     }
    ],
@@ -235,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -273,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -286,7 +298,7 @@
        "dict_keys(['https://api.qcarchive.molssi.org:443/'])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -311,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -321,19 +333,19 @@
     {
      "data": {
       "text/plain": [
-       "[TorsionDriveResult(type='torsion', record_id=21272367, cmiles='[H:16][c:1]1[c:2]([c:8]2[c:6]([c:3]([c:7]1[C:12]3=[C:10]([C:9](=[C:11]([O:15]3)[H:23])[H:21])[H:22])[H:18])[c:4]([n:13][c:5]([n:14]2)[H:20])[H:19])[H:17]', inchi_key='VQDKQTXZOFYKGJ-UHFFFAOYNA-N'),\n",
-       " TorsionDriveResult(type='torsion', record_id=21272361, cmiles='[H:13][C:1]1=[C:2]([C:8](=[O:12])[N:11]([C:6](=[C:3]1[H:15])[C:7]2=[N:9][C:4](=[C:5]([N:10]2[H:18])[H:17])[H:16])[H:19])[H:14]', inchi_key='ZKHASKWVHRESCJ-FLKJISBTNA-N'),\n",
-       " TorsionDriveResult(type='torsion', record_id=21272362, cmiles='[H:14][C:1]1=[C:2]([C:9](=[O:13])[N:11]([C:7](=[C:4]1[H:17])[C:8]2=[C:5]([C:3](=[C:6]([N:12]2[C:10]([H:20])([H:21])[H:22])[H:19])[H:16])[H:18])[H:23])[H:15]', inchi_key='HRRCFWLRKUBONR-WXRBYKJCNA-N'),\n",
-       " TorsionDriveResult(type='torsion', record_id=21272422, cmiles='[H:13][C:1]1=[C:2]([C:9](=[O:11])[N:10]([C:7](=[C:4]1[H:16])[C:8]2=[C:5]([C:3](=[C:6]([O:12]2)[H:18])[H:15])[H:17])[H:19])[H:14]', inchi_key='GODUVOSSXJHPKL-KZFATGLANA-N'),\n",
-       " TorsionDriveResult(type='torsion', record_id=21272428, cmiles='[H:13][C:1]1=[C:2]([C:9](=[O:11])[N:10]([C:7](=[C:4]1[H:16])[C:8]2=[C:5]([C:3](=[C:6]([S:12]2)[H:18])[H:15])[H:17])[H:19])[H:14]', inchi_key='OYXVCXRBUVWISS-KZFATGLANA-N'),\n",
-       " TorsionDriveResult(type='torsion', record_id=21272424, cmiles='[H:13][C:1]1=[C:2]([C:9](=[O:12])[N:10]([C:8](=[C:5]1[H:17])[N:11]2[C:6](=[C:3]([C:4](=[C:7]2[H:19])[H:16])[H:15])[H:18])[H:20])[H:14]', inchi_key='BRVTWSQOXUDDPJ-KZFATGLANA-N'),\n",
-       " TorsionDriveResult(type='torsion', record_id=21272429, cmiles='[H:13][C:1]1=[C:2]([C:9](=[O:12])[N:11]([C:8](=[C:4]1[H:16])[C:7]2=[C:5]([C:3](=[C:6]([N:10]2[H:19])[H:18])[H:15])[H:17])[H:20])[H:14]', inchi_key='OEXWTBSLUTZTHL-WXRBYKJCNA-N'),\n",
-       " TorsionDriveResult(type='torsion', record_id=21272432, cmiles='[H:13][C:1]1=[C:2]([C:9](=[O:11])[N:10]([C:8](=[C:3]1[H:15])[C:7]2=[C:6]([O:12][C:5](=[C:4]2[H:16])[H:17])[H:18])[H:19])[H:14]', inchi_key='KCBAOFOKUAYWRY-KZFATGLANA-N'),\n",
-       " TorsionDriveResult(type='torsion', record_id=21272425, cmiles='[H:13][C:1]1=[C:2]([C:9](=[O:11])[N:10]([C:8](=[C:3]1[H:15])[C:7]2=[C:6]([S:12][C:5](=[C:4]2[H:16])[H:17])[H:18])[H:19])[H:14]', inchi_key='VVVKIXJOGFLACL-KZFATGLANA-N'),\n",
-       " TorsionDriveResult(type='torsion', record_id=21272382, cmiles='[H:12][c:1]1[c:2]([c:5]([c:4]([n:9][c:3]1[H:14])[H:15])[C:8]2=[C:6]([N:11]([N:10]=[C:7]2[H:17])[H:18])[H:16])[H:13]', inchi_key='KFDSXKNTZIGCHU-KZFATGLANA-N')]"
+       "[TorsionDriveResult(type='torsion', record_id=104348544, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:25])[C@:18]([H:26])([C:19](=[O:20])[N:30]([H:35])[C@:31]([H:36])([C:32](=[O:33])[N:40]([H:42])[C:41]([H:43])([H:44])[H:45])[C:34]([H:37])([H:38])[H:39])[C:21]([H:27])([H:28])[C:22](=[O:23])[O:24][H:29])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='DFRSMLTYXUADOY-WMXHRXQGNA-N'),\n",
+       " TorsionDriveResult(type='torsion', record_id=104348638, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:25])[C@:18]([H:26])([C:19](=[O:20])[N:31]([H:36])[C@:32]([H:37])([C:33](=[O:34])[N:41]([H:43])[C:42]([H:44])([H:45])[H:46])[C:35]([H:38])([H:39])[H:40])[C:21]([H:27])([H:28])[C:22](=[O:23])[N:24]([H:29])[H:30])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='KYQIKKWSTMGEQA-RIYGDZFYNA-N'),\n",
+       " TorsionDriveResult(type='torsion', record_id=104348640, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:25])[C@:18]([H:26])([C:19](=[O:20])[N:29]([H:34])[C@:30]([H:35])([C:31](=[O:32])[N:39]([H:41])[C:40]([H:42])([H:43])[H:44])[C:33]([H:36])([H:37])[H:38])[C:21]([H:27])([H:28])[C:22](=[O:24])[O-:23])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='DFRSMLTYXUADOY-YXJNUYKJNA-M'),\n",
+       " TorsionDriveResult(type='torsion', record_id=104350274, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:26])[C@:18]([H:27])([C:19](=[O:20])[N:33]([H:38])[C@:34]([H:39])([C:35](=[O:36])[N:43]([H:45])[C:44]([H:46])([H:47])[H:48])[C:37]([H:40])([H:41])[H:42])[C:21]([H:28])([H:29])[C:22]([H:30])([H:31])[C:23](=[O:24])[O:25][H:32])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='YVWAADJXUPAWMQ-MMEUZQAYNA-N'),\n",
+       " TorsionDriveResult(type='torsion', record_id=104350994, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:26])[C@:18]([H:27])([C:19](=[O:20])[N:34]([H:39])[C@:35]([H:40])([C:36](=[O:37])[N:44]([H:46])[C:45]([H:47])([H:48])[H:49])[C:38]([H:41])([H:42])[H:43])[C:21]([H:28])([H:29])[C:22]([H:30])([H:31])[C:23](=[O:24])[N:25]([H:32])[H:33])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='WGYPYUBMHJDXLX-XZTNJZJKNA-N'),\n",
+       " TorsionDriveResult(type='torsion', record_id=104352631, cmiles='[H:30][C@@:25]([C:26](=[O:27])[N:34]([H:36])[C:35]([H:37])([H:38])[H:39])([C:28]([H:31])([H:32])[H:33])[N:24]([H:29])[C:19](=[O:20])[C:18]([H:22])([H:23])[N:17]([H:21])[C:9](=[O:10])[C@:8]([H:13])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='MSZWGDWDOLQBKL-IABNWRJLNA-N'),\n",
+       " TorsionDriveResult(type='torsion', record_id=104353304, cmiles='[H:32][C:24]1=[C:22]([N:23]([C:25](=[N:26]1)[H:33])[H:31])[C:21]([H:29])([H:30])[C@@:18]([H:28])([C:19](=[O:20])[N:34]([H:39])[C@:35]([H:40])([C:36](=[O:37])[N:44]([H:46])[C:45]([H:47])([H:48])[H:49])[C:38]([H:41])([H:42])[H:43])[N:17]([H:27])[C:9](=[O:10])[C@:8]([H:13])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='AEUGKYSAGBPNIR-BOUJXIRCNA-N'),\n",
+       " TorsionDriveResult(type='torsion', record_id=104353308, cmiles='[H:32][C:24]1=[C:22]([N+:23](=[C:25]([N:26]1[H:34])[H:33])[H:31])[C:21]([H:29])([H:30])[C@@:18]([H:28])([C:19](=[O:20])[N:35]([H:40])[C@:36]([H:41])([C:37](=[O:38])[N:45]([H:47])[C:46]([H:48])([H:49])[H:50])[C:39]([H:42])([H:43])[H:44])[N:17]([H:27])[C:9](=[O:10])[C@:8]([H:13])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='AEUGKYSAGBPNIR-ICFOULITNA-O'),\n",
+       " TorsionDriveResult(type='torsion', record_id=104353312, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:25])[C@:18]([H:26])([C:19](=[O:20])[N:36]([H:41])[C@:37]([H:42])([C:38](=[O:39])[N:46]([H:48])[C:47]([H:49])([H:50])[H:51])[C:40]([H:43])([H:44])[H:45])[C:21]([H:27])([H:28])[C:22]([H:29])([C:23]([H:30])([H:31])[H:32])[C:24]([H:33])([H:34])[H:35])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='JTPXVQPOMDABBJ-QNCMGGKINA-N'),\n",
+       " TorsionDriveResult(type='torsion', record_id=104353318, cmiles='[H:13][C@@:8]([C:9](=[O:10])[N:17]([H:25])[C@:18]([H:26])([C:19](=[O:20])[N:34]([H:39])[C@:35]([H:40])([C:36](=[O:37])[N:44]([H:46])[C:45]([H:47])([H:48])[H:49])[C:38]([H:41])([H:42])[H:43])[C:21]([H:27])([H:28])[C:22]([H:29])([H:30])[S:23][C:24]([H:31])([H:32])[H:33])([C:11]([H:14])([H:15])[H:16])[N:7]([H:12])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='ZGBZZLLRJFEPFE-SLHFYQOHNA-N')]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -358,41 +370,66 @@
     "\n",
     "## Retrieving the result records\n",
     "\n",
-    "The raw result record objects can be easily retrieved using the result collection objects:"
+    "The raw result record objects can be easily retrieved using the result collection objects. This allows us to filter the collection to only retrieve the results we want. We'll talk more about filters in an upcoming section, but for now we just apply a SMARTS string to limit our record download to the cysteine record:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "scrolled": true
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(TorsiondriveRecord(id=21272367, record_type='torsiondrive', is_service=True, properties={}, extras={}, status=<RecordStatusEnum.complete: 'complete'>, manager_name=None, created_on=datetime.datetime(2020, 7, 21, 16, 42, 25, 709146, tzinfo=datetime.timezone.utc), modified_on=datetime.datetime(2020, 7, 21, 16, 42, 25, 709145, tzinfo=datetime.timezone.utc), owner_user=None, owner_group=None, compute_history_=None, task_=None, service_=None, comments_=None, native_files_=None, specification=TorsiondriveSpecification(program='torsiondrive', optimization_specification=OptimizationSpecification(program='geometric', qc_specification=QCSpecification(program='psi4', driver=<SinglepointDriver.deferred: 'deferred'>, method='b3lyp-d3bj', basis='dzvp', keywords={'maxiter': 200, 'scf_properties': ['dipole', 'quadrupole', 'wiberg_lowdin_indices', 'mayer_indices']}, protocols=AtomicResultProtocols(wavefunction=<WavefunctionProtocolEnum.none: 'none'>, stdout=True, error_correction=ErrorCorrectionProtocol(default_policy=True, policies=None), native_files=<NativeFilesProtocolEnum.none: 'none'>)), keywords={'tmax': 0.3, 'check': 0, 'qccnv': True, 'reset': True, 'trust': 0.1, 'molcnv': False, 'enforce': 0.1, 'epsilon': 0, 'maxiter': 300, 'coordsys': 'tric', 'convergence_set': 'gau'}, protocols=OptimizationProtocols(trajectory=<TrajectoryProtocolEnum.all: 'all'>)), keywords=TorsiondriveKeywords(dihedrals=[(0, 6, 11, 14)], grid_spacing=[15], dihedral_ranges=None, energy_decrease_thresh=None, energy_upper_limit=0.05)), initial_molecules_ids_=None, initial_molecules_=None, optimizations_=None, minimum_optimizations_={'[0]': 21274152, '[15]': 21320903, '[30]': 21324390, '[45]': 21328551, '[60]': 21360439, '[75]': 21361004, '[90]': 21361472, '[-15]': 21320833, '[-30]': 21324389, '[-45]': 21328550, '[-60]': 21324388, '[-75]': 21328549, '[-90]': 21361471, '[105]': 21361005, '[120]': 21361473, '[135]': 21375288, '[150]': 21362939, '[165]': 21375289, '[180]': 21406971, '[-105]': 21362109, '[-120]': 21361470, '[-135]': 21362108, '[-150]': 21362799, '[-165]': 21409938}),\n",
-       "  Molecule with name '' and SMILES '[H]c1c(c2c(c(c1C3=C(C(=C(O3)[H])[H])[H])[H])c(nc(n2)[H])[H])[H]'),\n",
-       " (TorsiondriveRecord(id=21272361, record_type='torsiondrive', is_service=True, properties={}, extras={}, status=<RecordStatusEnum.complete: 'complete'>, manager_name=None, created_on=datetime.datetime(2020, 7, 21, 16, 42, 24, 673961, tzinfo=datetime.timezone.utc), modified_on=datetime.datetime(2020, 7, 21, 16, 42, 24, 673959, tzinfo=datetime.timezone.utc), owner_user=None, owner_group=None, compute_history_=None, task_=None, service_=None, comments_=None, native_files_=None, specification=TorsiondriveSpecification(program='torsiondrive', optimization_specification=OptimizationSpecification(program='geometric', qc_specification=QCSpecification(program='psi4', driver=<SinglepointDriver.deferred: 'deferred'>, method='b3lyp-d3bj', basis='dzvp', keywords={'maxiter': 200, 'scf_properties': ['dipole', 'quadrupole', 'wiberg_lowdin_indices', 'mayer_indices']}, protocols=AtomicResultProtocols(wavefunction=<WavefunctionProtocolEnum.none: 'none'>, stdout=True, error_correction=ErrorCorrectionProtocol(default_policy=True, policies=None), native_files=<NativeFilesProtocolEnum.none: 'none'>)), keywords={'tmax': 0.3, 'check': 0, 'qccnv': True, 'reset': True, 'trust': 0.1, 'molcnv': False, 'enforce': 0.1, 'epsilon': 0, 'maxiter': 300, 'coordsys': 'tric', 'convergence_set': 'gau'}, protocols=OptimizationProtocols(trajectory=<TrajectoryProtocolEnum.all: 'all'>)), keywords=TorsiondriveKeywords(dihedrals=[(10, 5, 6, 8)], grid_spacing=[15], dihedral_ranges=None, energy_decrease_thresh=None, energy_upper_limit=0.05)), initial_molecules_ids_=None, initial_molecules_=None, optimizations_=None, minimum_optimizations_={'[0]': 21359040, '[15]': 21356947, '[30]': 21357728, '[45]': 21353916, '[60]': 21355573, '[75]': 21353917, '[90]': 21346570, '[-15]': 21359371, '[-30]': 21359038, '[-45]': 21358234, '[-60]': 21359037, '[-75]': 21358233, '[-90]': 21357725, '[105]': 21348925, '[120]': 21274797, '[135]': 21272670, '[150]': 21272449, '[165]': 21272671, '[180]': 21346593, '[-105]': 21356945, '[-120]': 21350907, '[-135]': 21353914, '[-150]': 21346569, '[-165]': 21344548}),\n",
-       "  Molecule with name '' and SMILES '[H]C1=C(C(=O)N(C(=C1[H])C2=NC(=C(N2[H])[H])[H])[H])[H]'),\n",
-       " (TorsiondriveRecord(id=21272362, record_type='torsiondrive', is_service=True, properties={}, extras={}, status=<RecordStatusEnum.complete: 'complete'>, manager_name=None, created_on=datetime.datetime(2020, 7, 21, 16, 42, 24, 824865, tzinfo=datetime.timezone.utc), modified_on=datetime.datetime(2020, 7, 21, 16, 42, 24, 824864, tzinfo=datetime.timezone.utc), owner_user=None, owner_group=None, compute_history_=None, task_=None, service_=None, comments_=None, native_files_=None, specification=TorsiondriveSpecification(program='torsiondrive', optimization_specification=OptimizationSpecification(program='geometric', qc_specification=QCSpecification(program='psi4', driver=<SinglepointDriver.deferred: 'deferred'>, method='b3lyp-d3bj', basis='dzvp', keywords={'maxiter': 200, 'scf_properties': ['dipole', 'quadrupole', 'wiberg_lowdin_indices', 'mayer_indices']}, protocols=AtomicResultProtocols(wavefunction=<WavefunctionProtocolEnum.none: 'none'>, stdout=True, error_correction=ErrorCorrectionProtocol(default_policy=True, policies=None), native_files=<NativeFilesProtocolEnum.none: 'none'>)), keywords={'tmax': 0.3, 'check': 0, 'qccnv': True, 'reset': True, 'trust': 0.1, 'molcnv': False, 'enforce': 0.1, 'epsilon': 0, 'maxiter': 300, 'coordsys': 'tric', 'convergence_set': 'gau'}, protocols=OptimizationProtocols(trajectory=<TrajectoryProtocolEnum.all: 'all'>)), keywords=TorsiondriveKeywords(dihedrals=[(10, 6, 7, 11)], grid_spacing=[15], dihedral_ranges=None, energy_decrease_thresh=None, energy_upper_limit=0.05)), initial_molecules_ids_=None, initial_molecules_=None, optimizations_=None, minimum_optimizations_={'[0]': 21344327, '[15]': 21341333, '[30]': 21344329, '[45]': 21346108, '[60]': 21347926, '[75]': 21346109, '[90]': 21347943, '[-15]': 21341332, '[-30]': 21328164, '[-45]': 21323590, '[-60]': 21272450, '[-75]': 21272709, '[-90]': 21284985, '[105]': 21323596, '[120]': 21328168, '[135]': 21341336, '[150]': 21328169, '[165]': 21341337, '[180]': 21344332, '[-105]': 21346107, '[-120]': 21347924, '[-135]': 21341330, '[-150]': 21344325, '[-165]': 21346104}),\n",
-       "  Molecule with name '' and SMILES '[H]C1=C(C(=O)N(C(=C1[H])C2=C(C(=C(N2C([H])([H])[H])[H])[H])[H])[H])[H]'),\n",
-       " (TorsiondriveRecord(id=21272422, record_type='torsiondrive', is_service=True, properties={}, extras={}, status=<RecordStatusEnum.complete: 'complete'>, manager_name=None, created_on=datetime.datetime(2020, 7, 21, 16, 42, 34, 959088, tzinfo=datetime.timezone.utc), modified_on=datetime.datetime(2020, 7, 21, 16, 42, 34, 959086, tzinfo=datetime.timezone.utc), owner_user=None, owner_group=None, compute_history_=None, task_=None, service_=None, comments_=None, native_files_=None, specification=TorsiondriveSpecification(program='torsiondrive', optimization_specification=OptimizationSpecification(program='geometric', qc_specification=QCSpecification(program='psi4', driver=<SinglepointDriver.deferred: 'deferred'>, method='b3lyp-d3bj', basis='dzvp', keywords={'maxiter': 200, 'scf_properties': ['dipole', 'quadrupole', 'wiberg_lowdin_indices', 'mayer_indices']}, protocols=AtomicResultProtocols(wavefunction=<WavefunctionProtocolEnum.none: 'none'>, stdout=True, error_correction=ErrorCorrectionProtocol(default_policy=True, policies=None), native_files=<NativeFilesProtocolEnum.none: 'none'>)), keywords={'tmax': 0.3, 'check': 0, 'qccnv': True, 'reset': True, 'trust': 0.1, 'molcnv': False, 'enforce': 0.1, 'epsilon': 0, 'maxiter': 300, 'coordsys': 'tric', 'convergence_set': 'gau'}, protocols=OptimizationProtocols(trajectory=<TrajectoryProtocolEnum.all: 'all'>)), keywords=TorsiondriveKeywords(dihedrals=[(9, 6, 7, 11)], grid_spacing=[15], dihedral_ranges=None, energy_decrease_thresh=None, energy_upper_limit=0.05)), initial_molecules_ids_=None, initial_molecules_=None, optimizations_=None, minimum_optimizations_={'[0]': 21272514, '[15]': 21326804, '[30]': 21330838, '[45]': 21345058, '[60]': 21330839, '[75]': 21345059, '[90]': 21347501, '[-15]': 21326803, '[-30]': 21330837, '[-45]': 21345057, '[-60]': 21330836, '[-75]': 21345056, '[-90]': 21347497, '[105]': 21345060, '[120]': 21347502, '[135]': 21326806, '[150]': 21330841, '[165]': 21273592, '[180]': 21272515, '[-105]': 21345055, '[-120]': 21330835, '[-135]': 21345054, '[-150]': 21330834, '[-165]': 21273589}),\n",
-       "  Molecule with name '' and SMILES '[H]C1=C(C(=O)N(C(=C1[H])C2=C(C(=C(O2)[H])[H])[H])[H])[H]'),\n",
-       " (TorsiondriveRecord(id=21272428, record_type='torsiondrive', is_service=True, properties={}, extras={}, status=<RecordStatusEnum.complete: 'complete'>, manager_name=None, created_on=datetime.datetime(2020, 7, 21, 16, 42, 35, 872352, tzinfo=datetime.timezone.utc), modified_on=datetime.datetime(2020, 7, 21, 16, 42, 35, 872350, tzinfo=datetime.timezone.utc), owner_user=None, owner_group=None, compute_history_=None, task_=None, service_=None, comments_=None, native_files_=None, specification=TorsiondriveSpecification(program='torsiondrive', optimization_specification=OptimizationSpecification(program='geometric', qc_specification=QCSpecification(program='psi4', driver=<SinglepointDriver.deferred: 'deferred'>, method='b3lyp-d3bj', basis='dzvp', keywords={'maxiter': 200, 'scf_properties': ['dipole', 'quadrupole', 'wiberg_lowdin_indices', 'mayer_indices']}, protocols=AtomicResultProtocols(wavefunction=<WavefunctionProtocolEnum.none: 'none'>, stdout=True, error_correction=ErrorCorrectionProtocol(default_policy=True, policies=None), native_files=<NativeFilesProtocolEnum.none: 'none'>)), keywords={'tmax': 0.3, 'check': 0, 'qccnv': True, 'reset': True, 'trust': 0.1, 'molcnv': False, 'enforce': 0.1, 'epsilon': 0, 'maxiter': 300, 'coordsys': 'tric', 'convergence_set': 'gau'}, protocols=OptimizationProtocols(trajectory=<TrajectoryProtocolEnum.all: 'all'>)), keywords=TorsiondriveKeywords(dihedrals=[(9, 6, 7, 11)], grid_spacing=[15], dihedral_ranges=None, energy_decrease_thresh=None, energy_upper_limit=0.05)), initial_molecules_ids_=None, initial_molecules_=None, optimizations_=None, minimum_optimizations_={'[0]': 21319609, '[15]': 21323730, '[30]': 21361926, '[45]': 21361442, '[60]': 21361927, '[75]': 21361443, '[90]': 21361929, '[-15]': 21273639, '[-30]': 21319594, '[-45]': 21323728, '[-60]': 21344588, '[-75]': 21361440, '[-90]': 21344587, '[105]': 21323731, '[120]': 21344592, '[135]': 21323732, '[150]': 21272523, '[165]': 21273641, '[180]': 21319613, '[-105]': 21362329, '[-120]': 21361923, '[-135]': 21361438, '[-150]': 21344586, '[-165]': 21361437}),\n",
-       "  Molecule with name '' and SMILES '[H]C1=C(C(=O)N(C(=C1[H])C2=C(C(=C(S2)[H])[H])[H])[H])[H]')]"
+       "TorsionDriveResultCollection(entries={'https://api.qcarchive.molssi.org:443/': [TorsionDriveResult(type='torsion', record_id=104349083, cmiles='[H:30][C@@:24]([C:25](=[O:26])[N:34]([H:41])[C@:35]([H:42])([C:36](=[O:37])[N:50]([H:52])[C:51]([H:53])([H:54])[H:55])[C:38]([H:43])([C:39]([H:44])([H:45])[H:46])[C:40]([H:47])([H:48])[H:49])([C:27]([H:31])([H:32])[S:28][H:33])[N:23]([H:29])[C:9](=[O:10])[C@:8]([H:15])([C:11]([H:16])([C:12]([H:17])([H:18])[H:19])[C:13]([H:20])([H:21])[H:22])[N:7]([H:14])[C:1](=[O:2])[C:3]([H:4])([H:5])[H:6]', inchi_key='NXZIIAGLOSBSES-BCDINFCLNA-N')]}, provenance={'applied-filters': {'SMARTSFilter-0': {'smarts_to_include': ['C[SH]'], 'smarts_to_exclude': None}}}, type='TorsionDriveResultCollection')"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "torsion_drive_records = torsion_drive_result_collection.to_records()\n",
-    "torsion_drive_records[:5]"
+    "from openff.qcsubmit.results.filters import SMARTSFilter\n",
+    "\n",
+    "filtered_collection = torsion_drive_result_collection.filter(\n",
+    "    SMARTSFilter(smarts_to_include=[\"C[SH]\"])\n",
+    ")\n",
+    "filtered_collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we can download the actual results. This can be very slow, so it's worth filtering aggressively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(TorsiondriveRecord(id=104349083, record_type='torsiondrive', is_service=True, properties={}, extras={}, status=<RecordStatusEnum.complete: 'complete'>, manager_name=None, created_on=datetime.datetime(2022, 5, 31, 3, 11, 41, 558377, tzinfo=datetime.timezone.utc), modified_on=datetime.datetime(2022, 5, 31, 3, 11, 41, 558375, tzinfo=datetime.timezone.utc), owner_user=None, owner_group=None, compute_history_=None, task_=None, service_=None, comments_=None, native_files_=None, specification=TorsiondriveSpecification(program='torsiondrive', optimization_specification=OptimizationSpecification(program='geometric', qc_specification=QCSpecification(program='psi4', driver=<SinglepointDriver.deferred: 'deferred'>, method='b3lyp-d3bj', basis='dzvp', keywords={'maxiter': 200, 'scf_properties': ['dipole', 'quadrupole', 'wiberg_lowdin_indices', 'mayer_indices']}, protocols=AtomicResultProtocols(wavefunction=<WavefunctionProtocolEnum.none: 'none'>, stdout=True, error_correction=ErrorCorrectionProtocol(default_policy=True, policies=None), native_files=<NativeFilesProtocolEnum.none: 'none'>)), keywords={'tmax': 0.3, 'check': 0, 'qccnv': True, 'reset': True, 'trust': 0.1, 'molcnv': False, 'enforce': 0.1, 'epsilon': 0, 'maxiter': 300, 'coordsys': 'dlc', 'constraints': {'set': [{'type': 'dihedral', 'value': -65.0, 'indices': [22, 23, 26, 27]}]}, 'convergence_set': 'gau'}, protocols=OptimizationProtocols(trajectory=<TrajectoryProtocolEnum.all: 'all'>)), keywords=TorsiondriveKeywords(dihedrals=[(8, 22, 23, 24), (22, 23, 24, 33)], grid_spacing=[15, 15], dihedral_ranges=[(-180, 165), (-180, 165)], energy_decrease_thresh=None, energy_upper_limit=0.05)), initial_molecules_ids_=None, initial_molecules_=None, optimizations_=None, minimum_optimizations_={'[0, 0]': 108906495, '[0, 15]': 105861438, '[0, 30]': 107405834, '[0, 45]': 110088520, '[0, 60]': 109544346, '[0, 75]': 105861454, '[0, 90]': 105861457, '[15, 0]': 110088528, '[30, 0]': 110303147, '[45, 0]': 109544448, '[60, 0]': 109544498, '[75, 0]': 110088636, '[90, 0]': 108906792, '[-15, 0]': 105861336, '[-30, 0]': 107405701, '[-45, 0]': 105861145, '[-60, 0]': 108906351, '[-75, 0]': 108906329, '[-90, 0]': 108906315, '[0, -15]': 107405827, '[0, -30]': 107405825, '[0, -45]': 110640763, '[0, -60]': 110542489, '[0, -75]': 105861411, '[0, -90]': 107405814, '[0, 105]': 104355892, '[0, 120]': 107405852, '[0, 135]': 108906509, '[0, 150]': 108906511, '[0, 165]': 107405861, '[0, 180]': 107405863, '[105, 0]': 107406269, '[120, 0]': 105862217, '[135, 0]': 105862332, '[15, 15]': 110303132, '[15, 30]': 110088532, '[15, 45]': 110303136, '[15, 60]': 108906551, '[15, 75]': 109544374, '[15, 90]': 105861572, '[150, 0]': 105862426, '[165, 0]': 107406447, '[180, 0]': 109544622, '[30, 15]': 110088554, '[30, 30]': 109544408, '[30, 45]': 110088557, '[30, 60]': 109544410, '[30, 75]': 110088559, '[30, 90]': 107406009, '[45, 15]': 110303172, '[45, 30]': 110303175, '[45, 45]': 110303177, '[45, 60]': 110088589, '[45, 75]': 109544459, '[45, 90]': 108906673, '[60, 15]': 110303198, '[60, 30]': 110542518, '[60, 45]': 110088618, '[60, 60]': 110088619, '[60, 75]': 110088621, '[60, 90]': 109544512, '[75, 15]': 110088638, '[75, 30]': 109544547, '[75, 45]': 109544550, '[75, 60]': 109544553, '[75, 75]': 109544554, '[75, 90]': 110088647, '[90, 15]': 109544578, '[90, 30]': 108906797, '[90, 45]': 109544582, '[90, 60]': 110088655, '[90, 75]': 110088656, '[90, 90]': 110303226, '[-105, 0]': 110088443, '[-120, 0]': 110303012, '[-135, 0]': 110088385, '[-15, 15]': 104355862, '[-15, 30]': 108906457, '[-15, 45]': 107405771, '[-15, 60]': 109544334, '[-15, 75]': 108906465, '[-15, 90]': 105861359, '[-150, 0]': 109544168, '[-165, 0]': 108906241, '[-30, 15]': 107405703, '[-30, 30]': 107405705, '[-30, 45]': 107405710, '[-30, 60]': 105861257, '[-30, 75]': 107405716, '[-30, 90]': 107405718, '[-45, 15]': 108906389, '[-45, 30]': 107405651, '[-45, 45]': 108906390, '[-45, 60]': 107405657, '[-45, 75]': 107405661, '[-45, 90]': 105861168, '[-60, 15]': 109544279, '[-60, 30]': 105861055, '[-60, 45]': 109544280, '[-60, 60]': 109544281, '[-60, 75]': 105861067, '[-60, 90]': 107405618, '[-75, 15]': 108906332, '[-75, 30]': 109544253, '[-75, 45]': 110088480, '[-75, 60]': 108906335, '[-75, 75]': 109544259, '[-75, 90]': 110088483, '[-90, 15]': 110303087, '[-90, 30]': 110088460, '[-90, 45]': 110303088, '[-90, 60]': 110088463, '[-90, 75]': 110088464, '[-90, 90]': 110303092, '[0, -105]': 108906486, '[0, -120]': 109544342, '[0, -135]': 107405807, '[0, -150]': 105861394, '[0, -165]': 108906478, '[105, 15]': 108906824, '[105, 30]': 107406272, '[105, 45]': 107406276, '[105, 60]': 105862138, '[105, 75]': 110303229, '[105, 90]': 107406283, '[120, 15]': 104356077, '[120, 30]': 105862225, '[120, 45]': 105862227, '[120, 60]': 104356080, '[120, 75]': 105862236, '[120, 90]': 105862242, '[135, 15]': 105862333, '[135, 30]': 105862338, '[135, 45]': 105862341, '[135, 60]': 107406338, '[135, 75]': 105862349, '[135, 90]': 107406342, '[15, -15]': 110088527, '[15, -30]': 109544367, '[15, -45]': 110542494, '[15, -60]': 110640767, '[15, -75]': 110542492, '[15, -90]': 108906530, '[15, 105]': 105861576, '[15, 120]': 105861579, '[15, 135]': 108906557, '[15, 150]': 107405948, '[15, 165]': 109544380, '[15, 180]': 107405953, '[150, 15]': 107406378, '[150, 30]': 105862435, '[150, 45]': 107406382, '[150, 60]': 105862442, '[150, 75]': 107406387, '[150, 90]': 105862450, '[165, 15]': 105862525, '[165, 30]': 109544600, '[165, 45]': 110088664, '[165, 60]': 105862539, '[165, 75]': 105862541, '[165, 90]': 107406470, '[180, 15]': 108906878, '[180, 30]': 109544625, '[180, 45]': 108906884, '[180, 60]': 109544630, '[180, 75]': 109544632, '[180, 90]': 109544634, '[30, -15]': 109544399, '[30, -30]': 110088550, '[30, -45]': 110303142, '[30, -60]': 110542499, '[30, -75]': 110303139, '[30, -90]': 110640769, '[30, 105]': 107406012, '[30, 120]': 108906610, '[30, 135]': 108906613, '[30, 150]': 109544420, '[30, 165]': 109544421, '[30, 180]': 109544424, '[45, -15]': 109544445, '[45, -30]': 109544442, '[45, -45]': 110303168, '[45, -60]': 110088576, '[45, -75]': 110542505, '[45, -90]': 110748886, '[45, 105]': 108906677, '[45, 120]': 109544466, '[45, 135]': 109544467, '[45, 150]': 110088594, '[45, 165]': 108906688, '[45, 180]': 109544476, '[60, -15]': 110088609, '[60, -30]': 108906703, '[60, -45]': 108906701, '[60, -60]': 109544487, '[60, -75]': 110542516, '[60, -90]': 110640779, '[60, 105]': 109544515, '[60, 120]': 107406147, '[60, 135]': 109544519, '[60, 150]': 109544521, '[60, 165]': 109544524, '[60, 180]': 108906728, '[75, -15]': 108906749, '[75, -30]': 109544539, '[75, -45]': 107406169, '[75, -60]': 110088635, '[75, -75]': 110640785, '[75, -90]': 110748890, '[75, 105]': 108906761, '[75, 120]': 108906763, '[75, 135]': 107406189, '[75, 150]': 108906766, '[75, 165]': 108906768, '[75, 180]': 109544567, '[90, -15]': 107406217, '[90, -30]': 107406214, '[90, -45]': 105862014, '[90, -60]': 108906784, '[90, -75]': 109544573, '[90, -90]': 105862002, '[90, 105]': 105862052, '[90, 120]': 109544586, '[90, 135]': 108906804, '[90, 150]': 108906805, '[90, 165]': 107406240, '[90, 180]': 108906808, '[-105, 15]': 110088445, '[-105, 30]': 110303059, '[-105, 45]': 110088447, '[-105, 60]': 110088450, '[-105, 75]': 110303065, '[-105, 90]': 110088452, '[-120, 15]': 110542406, '[-120, 30]': 110542407, '[-120, 45]': 110748868, '[-120, 60]': 110640725, '[-120, 75]': 110542411, '[-120, 90]': 110640726, '[-135, 15]': 110302960, '[-135, 30]': 110542375, '[-135, 45]': 110640712, '[-135, 60]': 110542378, '[-135, 75]': 110302967, '[-135, 90]': 110088396, '[-15, -15]': 105861334, '[-15, -30]': 105861329, '[-15, -45]': 107405758, '[-15, -60]': 107405754, '[-15, -75]': 107405753, '[-15, -90]': 107405751, '[-15, 105]': 105861365, '[-15, 120]': 105861368, '[-15, 135]': 108906468, '[-15, 150]': 107405791, '[-15, 165]': 108906474, '[-15, 180]': 108906476, '[-150, 15]': 110088338, '[-150, 30]': 109544169, '[-150, 45]': 110542361, '[-150, 60]': 110640709, '[-150, 75]': 110088346, '[-150, 90]': 110302928, '[-165, 15]': 109544118, '[-165, 30]': 110088301, '[-165, 45]': 110088302, '[-165, 60]': 109544124, '[-165, 75]': 107405484, '[-165, 90]': 110088306, '[-30, -15]': 104355836, '[-30, -30]': 107405695, '[-30, -45]': 108906423, '[-30, -60]': 108906422, '[-30, -75]': 107405690, '[-30, -90]': 108906418, '[-30, 105]': 105861267, '[-30, 120]': 105861273, '[-30, 135]': 107405726, '[-30, 150]': 108906433, '[-30, 165]': 107405731, '[-30, 180]': 108906439, '[-45, -15]': 107405642, '[-45, -30]': 105861135, '[-45, -45]': 107405638, '[-45, -60]': 107405635, '[-45, -75]': 107405634, '[-45, -90]': 108906381, '[-45, 105]': 107405666, '[-45, 120]': 108906396, '[-45, 135]': 108906397, '[-45, 150]': 110303121, '[-45, 165]': 108906400, '[-45, 180]': 108906401, '[-60, -15]': 108906350, '[-60, -30]': 107405602, '[-60, -45]': 105861037, '[-60, -60]': 105861033, '[-60, -75]': 105861029, '[-60, -90]': 107405594, '[-60, 105]': 108906364, '[-60, 120]': 110088499, '[-60, 135]': 110303118, '[-60, 150]': 110088502, '[-60, 165]': 109544289, '[-60, 180]': 110088504, '[-75, -15]': 105860949, '[-75, -30]': 105860944, '[-75, -45]': 104355762, '[-75, -60]': 105860937, '[-75, -75]': 105860931, '[-75, -90]': 107405575, '[-75, 105]': 110303106, '[-75, 120]': 110088486, '[-75, 135]': 110088488, '[-75, 150]': 110640758, '[-75, 165]': 110542486, '[-75, 180]': 109544264, '[-90, -15]': 108906314, '[-90, -30]': 107405567, '[-90, -45]': 105860845, '[-90, -60]': 108906310, '[-90, -75]': 109544231, '[-90, -90]': 108906309, '[-90, 105]': 110088468, '[-90, 120]': 110640752, '[-90, 135]': 110640754, '[-90, 150]': 110542473, '[-90, 165]': 110640757, '[-90, 180]': 110542479, '[105, -15]': 105862118, '[105, -30]': 105862111, '[105, -45]': 105862108, '[105, -60]': 107406259, '[105, -75]': 107406258, '[105, -90]': 107406255, '[105, 105]': 105862147, '[105, 120]': 105862153, '[105, 135]': 107406286, '[105, 150]': 107406288, '[105, 165]': 105862163, '[105, 180]': 104356064, '[120, -15]': 105862214, '[120, -30]': 105862209, '[120, -45]': 105862204, '[120, -60]': 105862199, '[120, -75]': 105862196, '[120, -90]': 105862192, '[120, 105]': 105862246, '[120, 120]': 105862248, '[120, 135]': 105862253, '[120, 150]': 104356086, '[120, 165]': 104356087, '[120, 180]': 104356088, '[135, -15]': 104356099, '[135, -30]': 104356098, '[135, -45]': 105862302, '[135, -60]': 105862296, '[135, -75]': 104356095, '[135, -90]': 105862290, '[135, 105]': 105862359, '[135, 120]': 107406343, '[135, 135]': 107406344, '[135, 150]': 105862371, '[135, 165]': 104356111, '[135, 180]': 105862379, '[15, -105]': 107405878, '[15, -120]': 108906526, '[15, -135]': 108906524, '[15, -150]': 110088522, '[15, -165]': 108906521, '[150, -15]': 105862421, '[150, -30]': 105862417, '[150, -45]': 107406369, '[150, -60]': 105862410, '[150, -75]': 105862405, '[150, -90]': 105862401, '[150, 105]': 105862455, '[150, 120]': 105862458, '[150, 135]': 107406396, '[150, 150]': 105862467, '[150, 165]': 105862472, '[150, 180]': 107406404, '[165, -15]': 105862517, '[165, -30]': 107406443, '[165, -45]': 107406438, '[165, -60]': 107406434, '[165, -75]': 107406431, '[165, -90]': 105862498, '[165, 105]': 107406473, '[165, 120]': 105862555, '[165, 135]': 107406481, '[165, 150]': 107406485, '[165, 165]': 104356159, '[165, 180]': 108906855, '[180, -15]': 108906876, '[180, -30]': 109544617, '[180, -45]': 107406522, '[180, -60]': 105862601, '[180, -75]': 109544614, '[180, -90]': 108906867, '[180, 105]': 108906896, '[180, 120]': 107406562, '[180, 135]': 108906900, '[180, 150]': 105862657, '[180, 165]': 105862661, '[180, 180]': 108906905, '[30, -105]': 108906576, '[30, -120]': 109544390, '[30, -135]': 109544387, '[30, -150]': 109544385, '[30, -165]': 108906571, '[45, -105]': 110640773, '[45, -120]': 110303160, '[45, -135]': 110088567, '[45, -150]': 109544429, '[45, -165]': 109544428, '[60, -105]': 110748888, '[60, -120]': 110303189, '[60, -135]': 110542509, '[60, -150]': 110088598, '[60, -165]': 109544480, '[75, -105]': 110640784, '[75, -120]': 110542520, '[75, -135]': 110303211, '[75, -150]': 110303209, '[75, -165]': 110088631, '[90, -105]': 108906780, '[90, -120]': 107406201, '[90, -135]': 110303223, '[90, -150]': 110088650, '[90, -165]': 107406196, '[-105, -15]': 108906305, '[-105, -30]': 107405557, '[-105, -45]': 107405556, '[-105, -60]': 107405554, '[-105, -75]': 110088441, '[-105, -90]': 109544220, '[-105, 105]': 110303067, '[-105, 120]': 110640739, '[-105, 135]': 110640741, '[-105, 150]': 110847232, '[-105, 165]': 110748881, '[-105, 180]': 110303075, '[-120, -15]': 110542402, '[-120, -30]': 110542400, '[-120, -45]': 110303006, '[-120, -60]': 110542396, '[-120, -75]': 110640721, '[-120, -90]': 110302998, '[-120, 105]': 110088433, '[-120, 120]': 110640728, '[-120, 135]': 110640729, '[-120, 150]': 110748873, '[-120, 165]': 110640731, '[-120, 180]': 110542420, '[-135, -15]': 110302956, '[-135, -30]': 110542372, '[-135, -45]': 110542371, '[-135, -60]': 110302946, '[-135, -75]': 110542368, '[-135, -90]': 110088372, '[-135, 105]': 110302973, '[-135, 120]': 110088401, '[-135, 135]': 110302977, '[-135, 150]': 110302979, '[-135, 165]': 110542381, '[-135, 180]': 110542383, '[-15, -105]': 108906450, '[-15, -120]': 107405747, '[-15, -135]': 107405743, '[-15, -150]': 107405740, '[-15, -165]': 105861292, '[-150, -15]': 110088332, '[-150, -30]': 110088331, '[-150, -45]': 110088328, '[-150, -60]': 110640708, '[-150, -75]': 110302916, '[-150, -90]': 110302915, '[-150, 105]': 110088351, '[-150, 120]': 110302930, '[-150, 135]': 109544184, '[-150, 150]': 110302931, '[-150, 165]': 108906285, '[-150, 180]': 110302932, '[-165, -15]': 108906239, '[-165, -30]': 109544109, '[-165, -45]': 109544106, '[-165, -60]': 110542356, '[-165, -75]': 110640705, '[-165, -90]': 109544101, '[-165, 105]': 110088307, '[-165, 120]': 109544134, '[-165, 135]': 109544135, '[-165, 150]': 108906262, '[-165, 165]': 108906264, '[-165, 180]': 108906266, '[-30, -105]': 108906414, '[-30, -120]': 109544319, '[-30, -135]': 109544318, '[-30, -150]': 110088515, '[-30, -165]': 109544315, '[-45, -105]': 109544301, '[-45, -120]': 109544299, '[-45, -135]': 108906371, '[-45, -150]': 109544292, '[-45, -165]': 108906369, '[-60, -105]': 108906344, '[-60, -120]': 108906342, '[-60, -135]': 109544271, '[-60, -150]': 110088492, '[-60, -165]': 109544266, '[-75, -105]': 110088479, '[-75, -120]': 109544247, '[-75, -135]': 110303102, '[-75, -150]': 110542481, '[-75, -165]': 110088471, '[-90, -105]': 109544230, '[-90, -120]': 110088455, '[-90, -135]': 110542464, '[-90, -150]': 110640751, '[-90, -165]': 110847234, '[105, -105]': 105862092, '[105, -120]': 108906816, '[105, -135]': 107406250, '[105, -150]': 108906813, '[105, -165]': 105862076, '[120, -105]': 104356069, '[120, -120]': 105862186, '[120, -135]': 105862181, '[120, -150]': 105862178, '[120, -165]': 105862174, '[135, -105]': 105862285, '[135, -120]': 105862281, '[135, -135]': 107406325, '[135, -150]': 104356090, '[135, -165]': 105862267, '[150, -105]': 105862398, '[150, -120]': 105862394, '[150, -135]': 105862389, '[150, -150]': 105862386, '[150, -165]': 105862381, '[165, -105]': 107406424, '[165, -120]': 105862490, '[165, -135]': 107406417, '[165, -150]': 107406414, '[165, -165]': 105862479, '[180, -105]': 107406508, '[180, -120]': 108906863, '[180, -135]': 109544609, '[180, -150]': 105862577, '[180, -165]': 107406495, '[-105, -105]': 110088440, '[-105, -120]': 110542430, '[-105, -135]': 110640735, '[-105, -150]': 110640734, '[-105, -165]': 110748875, '[-120, -105]': 110542391, '[-120, -120]': 110542390, '[-120, -135]': 110302990, '[-120, -150]': 110302988, '[-120, -165]': 110542384, '[-135, -105]': 110542366, '[-135, -120]': 110302938, '[-135, -135]': 110542365, '[-135, -150]': 110302935, '[-135, -165]': 110302934, '[-150, -105]': 109544154, '[-150, -120]': 109544151, '[-150, -135]': 108906271, '[-150, -150]': 109544146, '[-150, -165]': 110302914, '[-165, -105]': 109544099, '[-165, -120]': 109544096, '[-165, -135]': 108906225, '[-165, -150]': 109544089, '[-165, -165]': 110088285}),\n",
+       "  Molecule with name '' and SMILES '[H][C@@](C(=O)N([H])[C@]([H])(C(=O)N([H])C([H])([H])[H])C([H])(C([H])([H])[H])C([H])([H])[H])(C([H])([H])S[H])N([H])C(=O)[C@]([H])(C([H])(C([H])([H])[H])C([H])([H])[H])N([H])C(=O)C([H])([H])[H]')]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torsion_drive_records = filtered_collection.to_records()\n",
+    "torsion_drive_records"
    ]
   },
   {
@@ -410,13 +447,15 @@
     "Notice that not only are the raw result records retrieved, but also an OpenFF `Molecule` object is created for each result record. This molecule has the correct ordering and also stores any conformers associated with the\n",
     "result collection. For basic collections, the conformer is the one that was used in any calculations; for optimization collections, it is the final conformer yielded by the optimization; and for torsion drives, it is the lowest energy conformer for each sampled torsion angle.\n",
     "\n",
+    "### Inspecting results\n",
+    "\n",
     "In the case of torsion drive records, we can easily iterate over the grid ID, the associated conformer, and the\n",
     "associated energy in one go:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -427,36 +466,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(-165,) E=-646.9155 Ha\n",
-      "(-150,) E=-646.9142 Ha\n",
-      "(-135,) E=-646.9120 Ha\n",
-      "(-120,) E=-646.9095 Ha\n",
-      "(-105,) E=-646.9073 Ha\n",
-      "(-90,) E=-646.9066 Ha\n",
-      "(-75,) E=-646.9077 Ha\n",
-      "(-60,) E=-646.9099 Ha\n",
-      "(-45,) E=-646.9123 Ha\n",
-      "(-30,) E=-646.9140 Ha\n",
-      "(-15,) E=-646.9149 Ha\n",
-      "(0,) E=-646.9151 Ha\n",
-      "(15,) E=-646.9149 Ha\n",
-      "(30,) E=-646.9140 Ha\n",
-      "(45,) E=-646.9123 Ha\n",
-      "(60,) E=-646.9099 Ha\n",
-      "(75,) E=-646.9077 Ha\n",
-      "(90,) E=-646.9066 Ha\n",
-      "(105,) E=-646.9073 Ha\n",
-      "(120,) E=-646.9095 Ha\n",
-      "(135,) E=-646.9120 Ha\n",
-      "(150,) E=-646.9142 Ha\n",
-      "(165,) E=-646.9155 Ha\n",
-      "(180,) E=-646.9158 Ha\n"
+      "(-165, -165) E=-1546.1642 Ha\n",
+      "(-165, -150) E=-1546.1627 Ha\n",
+      "(-165, -135) E=-1546.1621 Ha\n",
+      "(-165, -120) E=-1546.1617 Ha\n",
+      "(-165, -105) E=-1546.1625 Ha\n",
+      "(-165, -90) E=-1546.1642 Ha\n",
+      "(-165, -75) E=-1546.1666 Ha\n",
+      "(-165, -60) E=-1546.1682 Ha\n",
+      "(-165, -45) E=-1546.1684 Ha\n",
+      "(-165, -30) E=-1546.1689 Ha\n"
      ]
     }
    ],
    "source": [
     "torsion_drive_record, molecule = torsion_drive_records[0]\n",
-    "for grid_id, qc_conformer in zip(molecule.properties[\"grid_ids\"], molecule.conformers):\n",
+    "for grid_id, qc_conformer in zip(\n",
+    "    molecule.properties[\"grid_ids\"][:10], molecule.conformers\n",
+    "):\n",
     "    qc_energy = torsion_drive_record.final_energies[grid_id]\n",
     "\n",
     "    print(f\"{grid_id} E={qc_energy:.4f} Ha\")"
@@ -471,8 +498,108 @@
    },
    "source": [
     "We can also directly visualize the torsion drive using the built-in OpenFF Toolkit utilities using the\n",
-    "`molecule.visualize(\"nglview\")` function.\n",
+    "`molecule.visualize(\"nglview\")` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "01b5bdc4bba8494291178f464ea1369f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0374d1d805cf449f8071640e490e215a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GridBox(children=(FigureWidget({\n",
+       "    'data': [{'colorbar': {'title': {'text': 'Energy (Ha)'}},\n",
+       "              '…"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import plotly.graph_objects as go\n",
+    "from ipywidgets import widgets\n",
     "\n",
+    "energy_grid = np.zeros((24, 24))\n",
+    "psi_labels = [\"\"] * 24\n",
+    "phi_labels = [\"\"] * 24\n",
+    "for (phi, psi), qc_conformer in zip(\n",
+    "    molecule.properties[\"grid_ids\"], molecule.conformers\n",
+    "):\n",
+    "    qc_energy = torsion_drive_record.final_energies[(phi, psi)]\n",
+    "\n",
+    "    phi_bin = int(phi + 165) // 15\n",
+    "    psi_bin = int(psi + 165) // 15\n",
+    "    energy_grid[psi_bin, phi_bin] = qc_energy\n",
+    "    psi_labels[psi_bin] = psi\n",
+    "    phi_labels[phi_bin] = phi\n",
+    "\n",
+    "\n",
+    "fig = go.FigureWidget(\n",
+    "    data=go.Heatmap(\n",
+    "        z=energy_grid,\n",
+    "        x=phi_labels,\n",
+    "        y=psi_labels,\n",
+    "        colorbar={\"title\": \"Energy (Ha)\"},\n",
+    "        hovertemplate=\"phi: %{x}\\npsi: %{y}\\nenergy: %{z} Ha\",\n",
+    "    ),\n",
+    "    layout=go.Layout(\n",
+    "        title=\"Val-Ala-Val - central backbone torsiondrive (Ha)\",\n",
+    "        xaxis_title=\"Phi\",\n",
+    "        yaxis_title=\"Psi\",\n",
+    "        # autosize=False,\n",
+    "        yaxis_scaleanchor=\"x\",\n",
+    "        xaxis_scaleanchor=\"y\",\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "view = molecule.visualize(\"nglview\")\n",
+    "\n",
+    "\n",
+    "def on_click(trace, points, selector):\n",
+    "    print(points)\n",
+    "    for x, y in points.point_inds:\n",
+    "        view.frame = x * 24 + y\n",
+    "\n",
+    "\n",
+    "heatmap = fig.data[0]\n",
+    "heatmap.on_click(on_click)\n",
+    "\n",
+    "container = widgets.GridBox(\n",
+    "    [fig, view],\n",
+    ")\n",
+    "container"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
     "### Basic results from optimization results\n",
     "\n",
     "It is common for certain datasets within a QCFractal server to be created using the output of another dataset. This is especially the case for datasets of hessian records that are computed using the conformer produced by an optimization.\n",
@@ -482,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -495,7 +622,7 @@
        "2378"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,7 +653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -565,7 +692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -589,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -661,7 +788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -689,7 +816,7 @@
        "   'check_automorphs': True}}}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -716,7 +843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -764,7 +891,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/retrieving-results.ipynb
+++ b/examples/retrieving-results.ipynb
@@ -497,109 +497,6 @@
     }
    },
    "source": [
-    "We can also directly visualize the torsion drive using the built-in OpenFF Toolkit utilities using the\n",
-    "`molecule.visualize(\"nglview\")` function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "01b5bdc4bba8494291178f464ea1369f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0374d1d805cf449f8071640e490e215a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "GridBox(children=(FigureWidget({\n",
-       "    'data': [{'colorbar': {'title': {'text': 'Energy (Ha)'}},\n",
-       "              '…"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import numpy as np\n",
-    "import plotly.graph_objects as go\n",
-    "from ipywidgets import widgets\n",
-    "\n",
-    "energy_grid = np.zeros((24, 24))\n",
-    "psi_labels = [\"\"] * 24\n",
-    "phi_labels = [\"\"] * 24\n",
-    "for (phi, psi), qc_conformer in zip(\n",
-    "    molecule.properties[\"grid_ids\"], molecule.conformers\n",
-    "):\n",
-    "    qc_energy = torsion_drive_record.final_energies[(phi, psi)]\n",
-    "\n",
-    "    phi_bin = int(phi + 165) // 15\n",
-    "    psi_bin = int(psi + 165) // 15\n",
-    "    energy_grid[psi_bin, phi_bin] = qc_energy\n",
-    "    psi_labels[psi_bin] = psi\n",
-    "    phi_labels[phi_bin] = phi\n",
-    "\n",
-    "\n",
-    "fig = go.FigureWidget(\n",
-    "    data=go.Heatmap(\n",
-    "        z=energy_grid,\n",
-    "        x=phi_labels,\n",
-    "        y=psi_labels,\n",
-    "        colorbar={\"title\": \"Energy (Ha)\"},\n",
-    "        hovertemplate=\"phi: %{x}\\npsi: %{y}\\nenergy: %{z} Ha\",\n",
-    "    ),\n",
-    "    layout=go.Layout(\n",
-    "        title=\"Val-Ala-Val - central backbone torsiondrive (Ha)\",\n",
-    "        xaxis_title=\"Phi\",\n",
-    "        yaxis_title=\"Psi\",\n",
-    "        # autosize=False,\n",
-    "        yaxis_scaleanchor=\"x\",\n",
-    "        xaxis_scaleanchor=\"y\",\n",
-    "    ),\n",
-    ")\n",
-    "\n",
-    "view = molecule.visualize(\"nglview\")\n",
-    "\n",
-    "\n",
-    "def on_click(trace, points, selector):\n",
-    "    print(points)\n",
-    "    for x, y in points.point_inds:\n",
-    "        view.frame = x * 24 + y\n",
-    "\n",
-    "\n",
-    "heatmap = fig.data[0]\n",
-    "heatmap.on_click(on_click)\n",
-    "\n",
-    "container = widgets.GridBox(\n",
-    "    [fig, view],\n",
-    ")\n",
-    "container"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
     "### Basic results from optimization results\n",
     "\n",
     "It is common for certain datasets within a QCFractal server to be created using the output of another dataset. This is especially the case for datasets of hessian records that are computed using the conformer produced by an optimization.\n",
@@ -871,6 +768,107 @@
     "]\n",
     "\n",
     "molecules_to_pdf(molecules, \"energy-result-collection.pdf\", columns=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Advanced visualization\n",
+    "\n",
+    "Beyond the basic summary data shown above, we can also directly visualize the torsion drive using interactive `plotly` graphs and the `molecule.visualize(\"nglview\")` function from the OpenFF Toolkit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "01b5bdc4bba8494291178f464ea1369f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0374d1d805cf449f8071640e490e215a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GridBox(children=(FigureWidget({\n",
+       "    'data': [{'colorbar': {'title': {'text': 'Energy (Ha)'}},\n",
+       "              '…"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import plotly.graph_objects as go\n",
+    "from ipywidgets import widgets\n",
+    "\n",
+    "torsion_drive_record, molecule = torsion_drive_records[0]\n",
+    "energy_grid = np.zeros((24, 24))\n",
+    "psi_labels = [\"\"] * 24\n",
+    "phi_labels = [\"\"] * 24\n",
+    "for (phi, psi), qc_conformer in zip(\n",
+    "    molecule.properties[\"grid_ids\"], molecule.conformers\n",
+    "):\n",
+    "    qc_energy = torsion_drive_record.final_energies[(phi, psi)]\n",
+    "\n",
+    "    phi_bin = int(phi + 165) // 15\n",
+    "    psi_bin = int(psi + 165) // 15\n",
+    "    energy_grid[psi_bin, phi_bin] = qc_energy\n",
+    "    psi_labels[psi_bin] = psi\n",
+    "    phi_labels[phi_bin] = phi\n",
+    "\n",
+    "\n",
+    "fig = go.FigureWidget(\n",
+    "    data=go.Heatmap(\n",
+    "        z=energy_grid,\n",
+    "        x=phi_labels,\n",
+    "        y=psi_labels,\n",
+    "        colorbar={\"title\": \"Energy (Ha)\"},\n",
+    "        hovertemplate=\"phi: %{x}\\npsi: %{y}\\nenergy: %{z} Ha\",\n",
+    "    ),\n",
+    "    layout=go.Layout(\n",
+    "        title=\"Val-Ala-Val - central backbone torsiondrive (Ha)\",\n",
+    "        xaxis_title=\"Phi\",\n",
+    "        yaxis_title=\"Psi\",\n",
+    "        # autosize=False,\n",
+    "        yaxis_scaleanchor=\"x\",\n",
+    "        xaxis_scaleanchor=\"y\",\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "view = molecule.visualize(\"nglview\")\n",
+    "\n",
+    "\n",
+    "def on_click(trace, points, selector):\n",
+    "    print(points)\n",
+    "    for x, y in points.point_inds:\n",
+    "        view.frame = x * 24 + y\n",
+    "\n",
+    "\n",
+    "heatmap = fig.data[0]\n",
+    "heatmap.on_click(on_click)\n",
+    "\n",
+    "container = widgets.GridBox(\n",
+    "    [fig, view],\n",
+    ")\n",
+    "container"
    ]
   },
   {


### PR DESCRIPTION
## Description
This PR adds the 2D torsion drive visualization from the 2024 SMIRNOFF workshop (gist [here](https://gist.github.com/j-wags/57cd258af4465610205da9e486791140#file-env-yaml)) to the existing `retrieving-results.ipynb` example. This was a pretty small change but also required adding `plotly` and `nglview` as dependencies in the CI environments and updating a little bit of the prose in the example.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add 2D torsion visualization to examples

## Status
- [ ] Ready to go