### PR TITLE
Use `get_records_with_cache` to cache `to_records` calls

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -230,6 +230,7 @@ Utilities
     :nosignatures:
     :toctree: api/generated/
 
+	CachedPortalClient
 	portal_client_manager
 
 Exceptions

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -230,7 +230,7 @@ Utilities
     :nosignatures:
     :toctree: api/generated/
 
-	CachedPortalClient
+	_CachedPortalClient
 	portal_client_manager
 
 Exceptions

--- a/openff/qcsubmit/_tests/results/test_filters.py
+++ b/openff/qcsubmit/_tests/results/test_filters.py
@@ -32,7 +32,7 @@ from openff.qcsubmit.results.filters import (
     SMILESFilter,
     UnperceivableStereoFilter,
 )
-from openff.qcsubmit.utils import CachedPortalClient, portal_client_manager
+from openff.qcsubmit.utils import _CachedPortalClient, portal_client_manager
 
 from . import RecordStatusEnum, SinglepointRecord
 
@@ -549,7 +549,7 @@ def test_unperceivable_stereo_filter(toolkits, n_expected, public_client):
 
     with (
         TemporaryDirectory() as d,
-        portal_client_manager(lambda a: CachedPortalClient(a, cache_dir=d)),
+        portal_client_manager(lambda a: _CachedPortalClient(a, cache_dir=d)),
     ):
         filtered = collection.filter(UnperceivableStereoFilter(toolkits=toolkits))
     assert filtered.n_results == n_expected

--- a/openff/qcsubmit/_tests/results/test_filters.py
+++ b/openff/qcsubmit/_tests/results/test_filters.py
@@ -1,12 +1,12 @@
 import datetime
 import logging
+from tempfile import TemporaryDirectory
 
 import numpy
 import pytest
 from openff.toolkit.topology import Molecule
 from openff.units import unit
 from qcelemental.models import DriverEnum
-from qcportal import PortalClient
 from qcportal.singlepoint import QCSpecification
 
 from openff.qcsubmit._pydantic import ValidationError
@@ -32,7 +32,7 @@ from openff.qcsubmit.results.filters import (
     SMILESFilter,
     UnperceivableStereoFilter,
 )
-from openff.qcsubmit.utils import portal_client_manager
+from openff.qcsubmit.utils import CachedPortalClient, portal_client_manager
 
 from . import RecordStatusEnum, SinglepointRecord
 
@@ -547,6 +547,9 @@ def test_unperceivable_stereo_filter(toolkits, n_expected, public_client):
     )
     assert collection.n_results == 1
 
-    with portal_client_manager(PortalClient):
+    with (
+        TemporaryDirectory() as d,
+        portal_client_manager(lambda a: CachedPortalClient(a, cache_dir=d)),
+    ):
         filtered = collection.filter(UnperceivableStereoFilter(toolkits=toolkits))
     assert filtered.n_results == n_expected

--- a/openff/qcsubmit/_tests/results/test_filters.py
+++ b/openff/qcsubmit/_tests/results/test_filters.py
@@ -6,6 +6,7 @@ import pytest
 from openff.toolkit.topology import Molecule
 from openff.units import unit
 from qcelemental.models import DriverEnum
+from qcportal import PortalClient
 from qcportal.singlepoint import QCSpecification
 
 from openff.qcsubmit._pydantic import ValidationError
@@ -31,6 +32,7 @@ from openff.qcsubmit.results.filters import (
     SMILESFilter,
     UnperceivableStereoFilter,
 )
+from openff.qcsubmit.utils import portal_client_manager
 
 from . import RecordStatusEnum, SinglepointRecord
 
@@ -545,5 +547,6 @@ def test_unperceivable_stereo_filter(toolkits, n_expected, public_client):
     )
     assert collection.n_results == 1
 
-    filtered = collection.filter(UnperceivableStereoFilter(toolkits=toolkits))
+    with portal_client_manager(PortalClient):
+        filtered = collection.filter(UnperceivableStereoFilter(toolkits=toolkits))
     assert filtered.n_results == n_expected

--- a/openff/qcsubmit/_tests/results/test_results.py
+++ b/openff/qcsubmit/_tests/results/test_results.py
@@ -8,6 +8,7 @@ import pytest
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from qcelemental.models import DriverEnum
+from qcportal import PortalClient
 from qcportal.torsiondrive import (
     TorsiondriveKeywords,
     TorsiondriveRecord,
@@ -26,6 +27,7 @@ from openff.qcsubmit.results import (
 )
 from openff.qcsubmit.results.filters import ResultFilter
 from openff.qcsubmit.results.results import TorsionDriveResult, _BaseResultCollection
+from openff.qcsubmit.utils import portal_client_manager
 
 from . import (
     OptimizationRecord,
@@ -315,7 +317,8 @@ def test_to_records(
         public_client, collection_name, spec_name=spec_name
     )
     assert collection.n_molecules == expected_n_mols
-    records_and_molecules = collection.to_records()
+    with portal_client_manager(PortalClient):
+        records_and_molecules = collection.to_records()
     assert len(records_and_molecules) == expected_n_recs
     record, molecule = records_and_molecules[0]
 
@@ -351,9 +354,10 @@ def test_optimization_to_basic_result_collection(public_client):
     optimization_result_collection = OptimizationResultCollection.from_server(
         public_client, ["OpenFF Gen 2 Opt Set 3 Pfizer Discrepancy"]
     )
-    basic_collection = optimization_result_collection.to_basic_result_collection(
-        "hessian"
-    )
+    with portal_client_manager(PortalClient):
+        basic_collection = optimization_result_collection.to_basic_result_collection(
+            "hessian"
+        )
     assert basic_collection.n_results == 197
     assert basic_collection.n_molecules == 49
 

--- a/openff/qcsubmit/_tests/results/test_results.py
+++ b/openff/qcsubmit/_tests/results/test_results.py
@@ -9,7 +9,6 @@ import pytest
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from qcelemental.models import DriverEnum
-from qcportal import PortalClient
 from qcportal.torsiondrive import (
     TorsiondriveKeywords,
     TorsiondriveRecord,

--- a/openff/qcsubmit/_tests/results/test_results.py
+++ b/openff/qcsubmit/_tests/results/test_results.py
@@ -3,6 +3,7 @@ Test the results packages when collecting from the public qcarchive.
 """
 
 import datetime
+from tempfile import TemporaryDirectory
 
 import pytest
 from openff.toolkit.topology import Molecule
@@ -27,7 +28,7 @@ from openff.qcsubmit.results import (
 )
 from openff.qcsubmit.results.filters import ResultFilter
 from openff.qcsubmit.results.results import TorsionDriveResult, _BaseResultCollection
-from openff.qcsubmit.utils import portal_client_manager
+from openff.qcsubmit.utils import CachedPortalClient, portal_client_manager
 
 from . import (
     OptimizationRecord,
@@ -317,7 +318,10 @@ def test_to_records(
         public_client, collection_name, spec_name=spec_name
     )
     assert collection.n_molecules == expected_n_mols
-    with portal_client_manager(PortalClient):
+    with (
+        TemporaryDirectory() as d,
+        portal_client_manager(lambda a: CachedPortalClient(a, d)),
+    ):
         records_and_molecules = collection.to_records()
     assert len(records_and_molecules) == expected_n_recs
     record, molecule = records_and_molecules[0]
@@ -354,7 +358,10 @@ def test_optimization_to_basic_result_collection(public_client):
     optimization_result_collection = OptimizationResultCollection.from_server(
         public_client, ["OpenFF Gen 2 Opt Set 3 Pfizer Discrepancy"]
     )
-    with portal_client_manager(PortalClient):
+    with (
+        TemporaryDirectory() as d,
+        portal_client_manager(lambda a: CachedPortalClient(a, d)),
+    ):
         basic_collection = optimization_result_collection.to_basic_result_collection(
             "hessian"
         )

--- a/openff/qcsubmit/_tests/results/test_results.py
+++ b/openff/qcsubmit/_tests/results/test_results.py
@@ -27,7 +27,7 @@ from openff.qcsubmit.results import (
 )
 from openff.qcsubmit.results.filters import ResultFilter
 from openff.qcsubmit.results.results import TorsionDriveResult, _BaseResultCollection
-from openff.qcsubmit.utils import CachedPortalClient, portal_client_manager
+from openff.qcsubmit.utils import _CachedPortalClient, portal_client_manager
 
 from . import (
     OptimizationRecord,
@@ -319,12 +319,12 @@ def test_to_records(
     assert collection.n_molecules == expected_n_mols
 
     def disconnected_client(addr, cache_dir):
-        ret = CachedPortalClient(addr, cache_dir)
+        ret = _CachedPortalClient(addr, cache_dir)
         ret._req_session = None
         return ret
 
     with TemporaryDirectory() as d:
-        client = CachedPortalClient(public_client.address, d)
+        client = _CachedPortalClient(public_client.address, d)
         with portal_client_manager(lambda _: client):
             with (
                 client._no_session(),
@@ -381,7 +381,7 @@ def test_optimization_to_basic_result_collection(public_client):
     )
     with (
         TemporaryDirectory() as d,
-        portal_client_manager(lambda a: CachedPortalClient(a, d)),
+        portal_client_manager(lambda a: _CachedPortalClient(a, d)),
     ):
         basic_collection = optimization_result_collection.to_basic_result_collection(
             "hessian"

--- a/openff/qcsubmit/_tests/test_submissions.py
+++ b/openff/qcsubmit/_tests/test_submissions.py
@@ -37,7 +37,7 @@ from openff.qcsubmit.results import (
     OptimizationResultCollection,
     TorsionDriveResultCollection,
 )
-from openff.qcsubmit.utils import get_data
+from openff.qcsubmit.utils import get_data, portal_client_manager
 
 
 def await_results(client, timeout=120, check_fn=PortalClient.get_singlepoints, ids=[1]):
@@ -1408,7 +1408,8 @@ def test_invalid_cmiles(fulltest_client, factory_type, result_collection_type):
     assert ds.specifications.keys() == {"default"}
     results = result_collection_type.from_datasets(datasets=ds)
     assert results.n_molecules == 1
-    records = results.to_records()
+    with portal_client_manager(PortalClient):
+        records = results.to_records()
     assert len(records) == 1
     # Single points and optimizations look here
     fulltest_client.modify_molecule(
@@ -1427,6 +1428,9 @@ def test_invalid_cmiles(fulltest_client, factory_type, result_collection_type):
     ds._cache_data.update_entries(entries)
     results = result_collection_type.from_datasets(datasets=ds)
     assert results.n_molecules == 1
-    with pytest.warns(UserWarning, match="invalid CMILES"):
+    with (
+        pytest.warns(UserWarning, match="invalid CMILES"),
+        portal_client_manager(PortalClient),
+    ):
         records = results.to_records()
     assert len(records) == 0

--- a/openff/qcsubmit/_tests/test_submissions.py
+++ b/openff/qcsubmit/_tests/test_submissions.py
@@ -4,6 +4,8 @@ Test submissions to a local qcarchive instance using different compute backends,
 Here we use the qcfractal snowflake fixture to set up the database.
 """
 
+from tempfile import TemporaryDirectory
+
 import pytest
 from openff.toolkit.topology import Molecule
 from qcelemental.models.procedures import OptimizationProtocols
@@ -37,7 +39,7 @@ from openff.qcsubmit.results import (
     OptimizationResultCollection,
     TorsionDriveResultCollection,
 )
-from openff.qcsubmit.utils import get_data, portal_client_manager
+from openff.qcsubmit.utils import CachedPortalClient, get_data, portal_client_manager
 
 
 def await_results(client, timeout=120, check_fn=PortalClient.get_singlepoints, ids=[1]):
@@ -1408,7 +1410,10 @@ def test_invalid_cmiles(fulltest_client, factory_type, result_collection_type):
     assert ds.specifications.keys() == {"default"}
     results = result_collection_type.from_datasets(datasets=ds)
     assert results.n_molecules == 1
-    with portal_client_manager(PortalClient):
+    with (
+        TemporaryDirectory() as d,
+        portal_client_manager(lambda a: CachedPortalClient(a, d)),
+    ):
         records = results.to_records()
     assert len(records) == 1
     # Single points and optimizations look here
@@ -1430,7 +1435,8 @@ def test_invalid_cmiles(fulltest_client, factory_type, result_collection_type):
     assert results.n_molecules == 1
     with (
         pytest.warns(UserWarning, match="invalid CMILES"),
-        portal_client_manager(PortalClient),
+        TemporaryDirectory() as d,
+        portal_client_manager(lambda a: CachedPortalClient(a, d)),
     ):
         records = results.to_records()
     assert len(records) == 0

--- a/openff/qcsubmit/_tests/test_submissions.py
+++ b/openff/qcsubmit/_tests/test_submissions.py
@@ -39,7 +39,7 @@ from openff.qcsubmit.results import (
     OptimizationResultCollection,
     TorsionDriveResultCollection,
 )
-from openff.qcsubmit.utils import CachedPortalClient, get_data, portal_client_manager
+from openff.qcsubmit.utils import _CachedPortalClient, get_data, portal_client_manager
 
 
 def await_results(client, timeout=120, check_fn=PortalClient.get_singlepoints, ids=[1]):
@@ -1412,7 +1412,7 @@ def test_invalid_cmiles(fulltest_client, factory_type, result_collection_type):
     assert results.n_molecules == 1
     with (
         TemporaryDirectory() as d,
-        portal_client_manager(lambda a: CachedPortalClient(a, d)),
+        portal_client_manager(lambda a: _CachedPortalClient(a, d)),
     ):
         records = results.to_records()
     assert len(records) == 1
@@ -1436,7 +1436,7 @@ def test_invalid_cmiles(fulltest_client, factory_type, result_collection_type):
     with (
         pytest.warns(UserWarning, match="invalid CMILES"),
         TemporaryDirectory() as d,
-        portal_client_manager(lambda a: CachedPortalClient(a, d)),
+        portal_client_manager(lambda a: _CachedPortalClient(a, d)),
     ):
         records = results.to_records()
     assert len(records) == 0

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -27,6 +27,7 @@ from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from openff.units import unit
 from qcportal import PortalClient
+from qcportal.cache import get_records_with_cache
 from qcportal.dataset_models import BaseDataset as QCPDataset
 from qcportal.optimization import OptimizationDataset, OptimizationRecord
 from qcportal.record_models import BaseRecord, RecordStatusEnum
@@ -43,6 +44,7 @@ from openff.qcsubmit.common_structures import Metadata, MoleculeAttributes, QCSp
 from openff.qcsubmit.datasets import BasicDataset
 from openff.qcsubmit.exceptions import RecordTypeError
 from openff.qcsubmit.utils.smirnoff import smirnoff_coverage, smirnoff_torsion_coverage
+from openff.qcsubmit.utils.utils import client_record_cache
 
 if TYPE_CHECKING:
     from openff.qcsubmit.results.filters import ResultFilter
@@ -382,10 +384,22 @@ class BasicResultCollection(_BaseResultCollection):
 
         for client_address, records in self.entries.items():
             client = PortalClient(client_address)
+            use_cache = client_record_cache(client)
 
             # TODO - batching/chunking (maybe in portal?)
             for record in records:
-                rec = client.get_singlepoints(record.record_id, include=["molecule"])
+                if use_cache:
+                    rec = get_records_with_cache(
+                        client,
+                        client.record_cache,
+                        SinglepointRecord,
+                        [record.record_id],
+                        include=["molecule"],
+                    )[0]
+                else:
+                    rec = client.get_singlepoints(
+                        record.record_id, include=["molecule"]
+                    )
 
                 # OpenFF molecule
                 try:
@@ -534,12 +548,23 @@ class OptimizationResultCollection(_BaseResultCollection):
 
         for client_address, results in self.entries.items():
             client = PortalClient(client_address)
+            use_cache = client_record_cache(client)
 
-            rec_ids = [result.record_id for result in results]
             # Do one big request to save time
-            opt_records = client.get_optimizations(
-                rec_ids, include=["initial_molecule", "final_molecule"]
-            )
+            rec_ids = [result.record_id for result in results]
+
+            if use_cache:
+                opt_records = get_records_with_cache(
+                    client,
+                    client.record_cache,
+                    OptimizationRecord,
+                    rec_ids,
+                    include=["initial_molecule", "final_molecule"],
+                )
+            else:
+                opt_records = client.get_optimizations(
+                    rec_ids, include=["initial_molecule", "final_molecule"]
+                )
             # Sort out which records from the request line up with which results
             opt_rec_id_to_result = dict()
             for result in results:
@@ -803,13 +828,23 @@ class TorsionDriveResultCollection(_BaseResultCollection):
 
         for client_address, records in self.entries.items():
             client = PortalClient(client_address)
+            use_cache = client_record_cache(client)
 
             # retrieve all torsiondrives at once, including their
             # minimum_optimizations
             record_ids = [r.record_id for r in records]
-            torsion_drive_records = client.get_torsiondrives(
-                record_ids, include=["minimum_optimizations"]
-            )
+            if use_cache:
+                torsion_drive_records = get_records_with_cache(
+                    client,
+                    client.record_cache,
+                    TorsiondriveRecord,
+                    record_ids,
+                    include=["minimum_optimizations"],
+                )
+            else:
+                torsion_drive_records = client.get_torsiondrives(
+                    record_ids, include=["minimum_optimizations"]
+                )
             for record, rec in zip(records, torsion_drive_records):
                 # OpenFF molecule
                 try:
@@ -825,10 +860,26 @@ class TorsionDriveResultCollection(_BaseResultCollection):
 
                 # retrieve all minimum_optimizations at once
                 opt_ids = [v.id for v in rec.minimum_optimizations.values()]
-                opt_records = client.get_optimizations(opt_ids)
+                if use_cache:
+                    opt_records = get_records_with_cache(
+                        client,
+                        client.record_cache,
+                        OptimizationRecord,
+                        opt_ids,
+                    )
+                else:
+                    opt_records = client.get_optimizations(opt_ids)
                 # retrieve all final_molecules at once
                 opt_final_molecule_ids = [r.final_molecule_id for r in opt_records]
-                opt_final_molecules = client.get_molecules(opt_final_molecule_ids)
+                if use_cache:
+                    opt_final_molecules = get_records_with_cache(
+                        client,
+                        client.record_cache,
+                        qcportal.molecules.Molecule,  # not sure this is right
+                        opt_final_molecule_ids,
+                    )
+                else:
+                    opt_final_molecules = client.get_molecules(opt_final_molecule_ids)
                 # Map of torsion drive keys to minimum optimization
                 qc_grid_molecules = list(
                     zip(rec.minimum_optimizations.keys(), opt_final_molecules)

--- a/openff/qcsubmit/utils/__init__.py
+++ b/openff/qcsubmit/utils/__init__.py
@@ -23,5 +23,5 @@ __all__ = [
     "get_symmetry_classes",
     "get_symmetry_group",
     "portal_client_manager",
-    "CachedPortalClient",
+    "_CachedPortalClient",
 ]

--- a/openff/qcsubmit/utils/__init__.py
+++ b/openff/qcsubmit/utils/__init__.py
@@ -1,4 +1,5 @@
 from openff.qcsubmit.utils.utils import (
+    CachedPortalClient,
     check_missing_stereo,
     chunk_generator,
     clean_strings,
@@ -22,4 +23,5 @@ __all__ = [
     "get_symmetry_classes",
     "get_symmetry_group",
     "portal_client_manager",
+    "CachedPortalClient",
 ]

--- a/openff/qcsubmit/utils/__init__.py
+++ b/openff/qcsubmit/utils/__init__.py
@@ -1,5 +1,5 @@
 from openff.qcsubmit.utils.utils import (
-    CachedPortalClient,
+    _CachedPortalClient,
     check_missing_stereo,
     chunk_generator,
     clean_strings,

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -43,6 +43,7 @@ class CachedPortalClient(PortalClient):
         *,
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[OptimizationRecord], List[Optional[OptimizationRecord]]]:
+        raise NotImplementedError()
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if unpack := not isinstance(record_ids, Sequence):
@@ -67,6 +68,7 @@ class CachedPortalClient(PortalClient):
         *,
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[SinglepointRecord], List[Optional[SinglepointRecord]]]:
+        raise NotImplementedError()
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if unpack := not isinstance(record_ids, Sequence):
@@ -91,6 +93,7 @@ class CachedPortalClient(PortalClient):
         *,
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[TorsiondriveRecord], List[Optional[TorsiondriveRecord]]]:
+        raise NotImplementedError()
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if unpack := not isinstance(record_ids, Sequence):

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -43,7 +43,6 @@ class CachedPortalClient(PortalClient):
         *,
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[OptimizationRecord], List[Optional[OptimizationRecord]]]:
-        raise NotImplementedError()
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if unpack := not isinstance(record_ids, Sequence):

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -26,6 +26,8 @@ from qcportal.torsiondrive.record_models import TorsiondriveRecord
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_CACHE_DIR = "./qcsubmit_qcportal_cache"
+
 
 class CachedPortalClient(PortalClient):
     def __init__(self, addr, cache_dir, **client_kwargs):
@@ -108,7 +110,7 @@ class CachedPortalClient(PortalClient):
 
 
 def _default_portal_client(client_address) -> PortalClient:
-    return CachedPortalClient(client_address, cache_dir="./qcsubmit_qcportal_cache")
+    return CachedPortalClient(client_address, cache_dir=_DEFAULT_CACHE_DIR)
 
 
 @contextmanager

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -122,7 +122,10 @@ class _CachedPortalClient(PortalClient):
             returns a list of records.
         """
         if missing_ok:
-            logger.warning("missing_ok provided but unused by CachedPortalClient")
+            logger.warning(
+                "missing_ok was set to True, but CachedPortalClient"
+                " doesn't actually support this so it's being set to False"
+            )
         if unpack := not isinstance(record_ids, Sequence):
             record_ids = [record_ids]
         res = get_records_with_cache(
@@ -168,7 +171,10 @@ class _CachedPortalClient(PortalClient):
             returns a list of records.
         """
         if missing_ok:
-            logger.warning("missing_ok provided but unused by CachedPortalClient")
+            logger.warning(
+                "missing_ok was set to True, but CachedPortalClient"
+                " doesn't actually support this so it's being set to False"
+            )
         if unpack := not isinstance(record_ids, Sequence):
             record_ids = [record_ids]
         res = get_records_with_cache(
@@ -214,7 +220,10 @@ class _CachedPortalClient(PortalClient):
             returns a list of records.
         """
         if missing_ok:
-            logger.warning("missing_ok provided but unused by CachedPortalClient")
+            logger.warning(
+                "missing_ok was set to True, but CachedPortalClient"
+                " doesn't actually support this so it's being set to False"
+            )
         if unpack := not isinstance(record_ids, Sequence):
             record_ids = [record_ids]
         res = get_records_with_cache(

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -27,7 +27,7 @@ from qcportal.torsiondrive.record_models import TorsiondriveRecord
 logger = logging.getLogger(__name__)
 
 
-class CachedPortalClient(PortalClient):
+class _CachedPortalClient(PortalClient):
     """A cached version of a `qcportal.PortalClient
     <https://molssi.github.io/QCFractal/user_guide/qcportal_reference.html#qcportal.client.PortalClient>`_.
     """

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -288,6 +288,9 @@ def portal_client_manager(portal_client_fn: Callable[[str], PortalClient]):
     >>> with portal_client_manager(my_portal_client):
     >>>     records_and_molecules = ds.to_records()
 
+    .. warning::
+        It is not safe to share the same client across threads or to construct
+        multiple clients accessing the same cache database.
     """
     global _default_portal_client
     original_client_fn = _default_portal_client

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -67,7 +67,6 @@ class CachedPortalClient(PortalClient):
         *,
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[SinglepointRecord], List[Optional[SinglepointRecord]]]:
-        raise NotImplementedError()
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if unpack := not isinstance(record_ids, Sequence):
@@ -92,7 +91,6 @@ class CachedPortalClient(PortalClient):
         *,
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[TorsiondriveRecord], List[Optional[TorsiondriveRecord]]]:
-        raise NotImplementedError()
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if unpack := not isinstance(record_ids, Sequence):

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -102,6 +102,27 @@ class CachedPortalClient(PortalClient):
         *,
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[OptimizationRecord], List[Optional[OptimizationRecord]]]:
+        """Obtain optimization records with the specified IDs.
+
+        Records will be returned in the same order as the record ids.
+
+        Parameters
+        ----------
+        record_ids
+            Single ID or sequence/list of records to obtain
+        missing_ok
+            Unlike a ``PortalClient``, this argument is ignored. If set to
+            True, a warning will be printed. Any missing records will cause a
+            ``RuntimeError`` to be raised.
+        include
+            Additional fields to include in the returned record
+
+        Returns
+        -------
+        :
+            If a single ID was specified, returns just that record. Otherwise,
+            returns a list of records.
+        """
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if unpack := not isinstance(record_ids, Sequence):
@@ -126,6 +147,28 @@ class CachedPortalClient(PortalClient):
         *,
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[SinglepointRecord], List[Optional[SinglepointRecord]]]:
+        """
+        Obtain singlepoint records with the specified IDs.
+
+        Records will be returned in the same order as the record ids.
+
+        Parameters
+        ----------
+        record_ids
+            Single ID or sequence/list of records to obtain
+        missing_ok
+            Unlike a ``PortalClient``, this argument is ignored. If set to
+            True, a warning will be printed. Any missing records will cause a
+            ``RuntimeError`` to be raised.
+        include
+            Additional fields to include in the returned record
+
+        Returns
+        -------
+        :
+            If a single ID was specified, returns just that record. Otherwise,
+            returns a list of records.
+        """
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if unpack := not isinstance(record_ids, Sequence):
@@ -150,6 +193,28 @@ class CachedPortalClient(PortalClient):
         *,
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[TorsiondriveRecord], List[Optional[TorsiondriveRecord]]]:
+        """
+        Obtain torsiondrive records with the specified IDs.
+
+        Records will be returned in the same order as the record ids.
+
+        Parameters
+        ----------
+        record_ids
+            Single ID or sequence/list of records to obtain
+        missing_ok
+            Unlike a ``PortalClient``, this argument is ignored. If set to
+            True, a warning will be printed. Any missing records will cause a
+            ``RuntimeError`` to be raised.
+        include
+            Additional fields to include in the returned record
+
+        Returns
+        -------
+        :
+            If a single ID was specified, returns just that record. Otherwise,
+            returns a list of records.
+        """
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if unpack := not isinstance(record_ids, Sequence):
@@ -175,7 +240,6 @@ class CachedPortalClient(PortalClient):
         accessing ``socket.socket`` again. Combining ``no_internet`` and
         ``client._no_session`` should completely ensure that the local cache is
         used rather than re-fetching data from QCArchive.
-
         """
         tmp = self._req_session
         self._req_session = None

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -5,21 +5,6 @@ from openff.toolkit.utils.toolkits import (
     RDKitToolkitWrapper,
     UndefinedStereochemistryError,
 )
-from qcportal import PortalClient
-from qcportal.cache import RecordCache
-
-
-def client_record_cache(client: PortalClient) -> bool:
-    """Initialize a RecordCache stored on `client` if the client already has a
-    cache_dir. Returns whether or not this was the case (whether caching should
-    be used)
-
-    """
-    if client.cache and client.cache.cache_dir:
-        if not hasattr(client, "record_cache"):
-            client.record_cache = RecordCache(client.cache.cache_dir, read_only=False)
-        return True
-    return False
 
 
 def get_data(relative_path):

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -20,7 +20,6 @@ from openff.toolkit.utils.toolkits import (
 )
 from qcportal import PortalClient
 from qcportal.cache import RecordCache, get_records_with_cache
-from qcportal.molecules import Molecule
 from qcportal.optimization.record_models import OptimizationRecord
 from qcportal.singlepoint.record_models import SinglepointRecord
 from qcportal.torsiondrive.record_models import TorsiondriveRecord
@@ -110,28 +109,35 @@ class CachedPortalClient(PortalClient):
         else:
             return res
 
-    def get_molecules(
-        self,
-        molecule_ids: Union[int, Sequence[int]],
-        missing_ok: bool = False,
-    ) -> Union[Optional[Molecule], List[Optional[Molecule]]]:
-        if missing_ok:
-            logger.warning("missing_ok provided but unused by CachedPortalClient")
-        if not isinstance(molecule_ids, Sequence):
-            unpack = True
-            molecule_ids = [molecule_ids]
-        res = get_records_with_cache(
-            client=self,
-            record_cache=self.record_cache,
-            record_type=Molecule,
-            record_ids=molecule_ids,
-            include=None,
-            force_fetch=False,
-        )
-        if unpack:
-            return res[0]
-        else:
-            return res
+    # Molecule is not a true record type (it's just re-exported from
+    # qcelemental), so it doesn't play well with the get_records_with_cache
+    # approach. get_records_with_cache calls client._fetch_records, which peeks
+    # at record_type.__fields__["record_type"] that Molecules don't have.
+    # PortalClient.get_molecules does all the work itself instead of delegating
+    # to _get_records_by_type and _fetch_records
+
+    # def get_molecules(
+    #     self,
+    #     molecule_ids: Union[int, Sequence[int]],
+    #     missing_ok: bool = False,
+    # ) -> Union[Optional[Molecule], List[Optional[Molecule]]]:
+    #     if missing_ok:
+    #         logger.warning("missing_ok provided but unused by CachedPortalClient")
+    #     if not isinstance(molecule_ids, Sequence):
+    #         unpack = True
+    #         molecule_ids = [molecule_ids]
+    #     res = get_records_with_cache(
+    #         client=self,
+    #         record_cache=self.record_cache,
+    #         record_type=Molecule,
+    #         record_ids=molecule_ids,
+    #         include=None,
+    #         force_fetch=False,
+    #     )
+    #     if unpack:
+    #         return res[0]
+    #     else:
+    #         return res
 
 
 def _default_portal_client(client_address) -> PortalClient:

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -269,6 +269,10 @@ def portal_client_manager(portal_client_fn: Callable[[str], PortalClient]):
     keyword arguments to the ``PortalClient``, such as ``verify=False`` or a
     ``cache_dir``.
 
+    .. warning::
+        It is not safe to share the same client across threads or to construct
+        multiple clients accessing the same cache database.
+
     Parameters
     ----------
     portal_client_fn:
@@ -287,10 +291,6 @@ def portal_client_manager(portal_client_fn: Callable[[str], PortalClient]):
     >>>     return PortalClient(client_address, cache_dir=".")
     >>> with portal_client_manager(my_portal_client):
     >>>     records_and_molecules = ds.to_records()
-
-    .. warning::
-        It is not safe to share the same client across threads or to construct
-        multiple clients accessing the same cache database.
     """
     global _default_portal_client
     original_client_fn = _default_portal_client

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -106,35 +106,6 @@ class CachedPortalClient(PortalClient):
         else:
             return res
 
-    # Molecule is not a true record type (it's just re-exported from
-    # qcelemental), so it doesn't play well with the get_records_with_cache
-    # approach. get_records_with_cache calls client._fetch_records, which peeks
-    # at record_type.__fields__["record_type"] that Molecules don't have.
-    # PortalClient.get_molecules does all the work itself instead of delegating
-    # to _get_records_by_type and _fetch_records
-
-    # def get_molecules(
-    #     self,
-    #     molecule_ids: Union[int, Sequence[int]],
-    #     missing_ok: bool = False,
-    # ) -> Union[Optional[Molecule], List[Optional[Molecule]]]:
-    #     if missing_ok:
-    #         logger.warning("missing_ok provided but unused by CachedPortalClient")
-    #     if unpack := not isinstance(molecule_ids, Sequence):
-    #         molecule_ids = [molecule_ids]
-    #     res = get_records_with_cache(
-    #         client=self,
-    #         record_cache=self.record_cache,
-    #         record_type=Molecule,
-    #         record_ids=molecule_ids,
-    #         include=None,
-    #         force_fetch=False,
-    #     )
-    #     if unpack:
-    #         return res[0]
-    #     else:
-    #         return res
-
 
 def _default_portal_client(client_address) -> PortalClient:
     return CachedPortalClient(client_address, cache_dir="./qcsubmit_qcportal_cache")

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, Generator, List, Tuple
 
 from openff.toolkit import topology as off
@@ -17,7 +18,9 @@ def client_record_cache(client: PortalClient) -> bool:
     """
     if client.cache and client.cache.cache_dir:
         if not hasattr(client, "record_cache"):
-            client.record_cache = RecordCache(client.cache.cache_dir, read_only=False)
+            client.record_cache = RecordCache(
+                os.path.join(client.cache.cache_dir, "cache.sqlite"), read_only=False
+            )
         return True
     return False
 

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -31,7 +31,7 @@ _DEFAULT_CACHE_DIR = "./qcsubmit_qcportal_cache"
 
 class CachedPortalClient(PortalClient):
     """A cached version of a `qcportal.PortalClient
-    <https://molssi.github.io/QCFractal/user_guide/qcportal_reference.html#qcportal.client.PortalClient>`.
+    <https://molssi.github.io/QCFractal/user_guide/qcportal_reference.html#qcportal.client.PortalClient>`_.
     """
 
     def __init__(

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict, Generator, List, Tuple
 
 from openff.toolkit import topology as off
@@ -18,9 +17,7 @@ def client_record_cache(client: PortalClient) -> bool:
     """
     if client.cache and client.cache.cache_dir:
         if not hasattr(client, "record_cache"):
-            client.record_cache = RecordCache(
-                os.path.join(client.cache.cache_dir, "cache.sqlite"), read_only=False
-            )
+            client.record_cache = RecordCache(client.cache.cache_dir, read_only=False)
         return True
     return False
 

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -86,7 +86,7 @@ class CachedPortalClient(PortalClient):
 
 
 def _default_portal_client(client_address) -> PortalClient:
-    return PortalClient(client_address)
+    return CachedPortalClient(client_address, cache_dir="./qcsubmit_qcportal_cache")
 
 
 @contextmanager

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -44,6 +44,8 @@ class CachedPortalClient(PortalClient):
     ) -> Union[Optional[OptimizationRecord], List[Optional[OptimizationRecord]]]:
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
+        if not isinstance(record_ids, Sequence):
+            record_ids = [record_ids]
         return get_records_with_cache(
             client=self,
             record_cache=self.record_cache,
@@ -62,7 +64,16 @@ class CachedPortalClient(PortalClient):
     ) -> Union[Optional[SinglepointRecord], List[Optional[SinglepointRecord]]]:
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
-        raise NotImplementedError()
+        if not isinstance(record_ids, Sequence):
+            record_ids = [record_ids]
+        return get_records_with_cache(
+            client=self,
+            record_cache=self.record_cache,
+            record_type=SinglepointRecord,
+            record_ids=record_ids,
+            include=include,
+            force_fetch=False,
+        )
 
     def get_torsiondrives(
         self,
@@ -73,7 +84,16 @@ class CachedPortalClient(PortalClient):
     ) -> Union[Optional[TorsiondriveRecord], List[Optional[TorsiondriveRecord]]]:
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
-        raise NotImplementedError()
+        if not isinstance(record_ids, Sequence):
+            record_ids = [record_ids]
+        return get_records_with_cache(
+            client=self,
+            record_cache=self.record_cache,
+            record_type=TorsiondriveRecord,
+            record_ids=record_ids,
+            include=include,
+            force_fetch=False,
+        )
 
     def get_molecules(
         self,
@@ -82,7 +102,16 @@ class CachedPortalClient(PortalClient):
     ) -> Union[Optional[Molecule], List[Optional[Molecule]]]:
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
-        raise NotImplementedError()
+        if not isinstance(molecule_ids, Sequence):
+            molecule_ids = [molecule_ids]
+        return get_records_with_cache(
+            client=self,
+            record_cache=self.record_cache,
+            record_type=Molecule,
+            record_ids=molecule_ids,
+            include=None,
+            force_fetch=False,
+        )
 
 
 def _default_portal_client(client_address) -> PortalClient:

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -43,8 +43,7 @@ class CachedPortalClient(PortalClient):
     ) -> Union[Optional[OptimizationRecord], List[Optional[OptimizationRecord]]]:
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
-        if not isinstance(record_ids, Sequence):
-            unpack = True
+        if unpack := not isinstance(record_ids, Sequence):
             record_ids = [record_ids]
         res = get_records_with_cache(
             client=self,
@@ -68,8 +67,7 @@ class CachedPortalClient(PortalClient):
     ) -> Union[Optional[SinglepointRecord], List[Optional[SinglepointRecord]]]:
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
-        if not isinstance(record_ids, Sequence):
-            unpack = True
+        if unpack := not isinstance(record_ids, Sequence):
             record_ids = [record_ids]
         res = get_records_with_cache(
             client=self,
@@ -93,8 +91,7 @@ class CachedPortalClient(PortalClient):
     ) -> Union[Optional[TorsiondriveRecord], List[Optional[TorsiondriveRecord]]]:
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
-        if not isinstance(record_ids, Sequence):
-            unpack = True
+        if unpack := not isinstance(record_ids, Sequence):
             record_ids = [record_ids]
         res = get_records_with_cache(
             client=self,
@@ -123,8 +120,7 @@ class CachedPortalClient(PortalClient):
     # ) -> Union[Optional[Molecule], List[Optional[Molecule]]]:
     #     if missing_ok:
     #         logger.warning("missing_ok provided but unused by CachedPortalClient")
-    #     if not isinstance(molecule_ids, Sequence):
-    #         unpack = True
+    #     if unpack := not isinstance(molecule_ids, Sequence):
     #         molecule_ids = [molecule_ids]
     #     res = get_records_with_cache(
     #         client=self,

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -108,6 +108,23 @@ class CachedPortalClient(PortalClient):
         else:
             return res
 
+    @contextmanager
+    def _no_session(self):
+        """This is a supplemental context manager to the ``no_internet``
+        manager in _tests/utils/test_manager.py. ``PortalClient`` creates a
+        ``requests.Session`` on initialization that can be reused without
+        accessing ``socket.socket`` again. Combining ``no_internet`` and
+        ``client._no_session`` should completely ensure that the local cache is
+        used rather than re-fetching data from QCArchive.
+
+        """
+        tmp = self._req_session
+        self._req_session = None
+        try:
+            yield
+        finally:
+            self._req_session = tmp
+
 
 def _default_portal_client(client_address) -> PortalClient:
     return CachedPortalClient(client_address, cache_dir=_DEFAULT_CACHE_DIR)

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -30,8 +30,54 @@ _DEFAULT_CACHE_DIR = "./qcsubmit_qcportal_cache"
 
 
 class CachedPortalClient(PortalClient):
-    def __init__(self, addr, cache_dir, **client_kwargs):
-        super().__init__(addr, cache_dir=cache_dir, **client_kwargs)
+    """A cached version of a `qcportal.PortalClient
+    <https://molssi.github.io/QCFractal/user_guide/qcportal_reference.html#qcportal.client.PortalClient>`.
+    """
+
+    def __init__(
+        self,
+        address: str,
+        cache_dir: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        verify: bool = True,
+        show_motd: bool = True,
+        *,
+        cache_max_size: int = 0,
+        memory_cache_key: Optional[str] = None,
+    ):
+        """Parameters
+        ----------
+        address
+            The host or IP address of the FractalServer instance, including
+            protocol and port if necessary ("https://ml.qcarchive.molssi.org",
+            "http://192.168.1.10:8888")
+        cache_dir
+            Directory to store an internal cache of records and other data.
+            Unlike a normal ``PortalClient``, this argument is required.
+        username
+            The username to authenticate with.
+        password
+            The password to authenticate with.
+        verify
+            Verifies the SSL connection with a third party server. This may be
+            False if a FractalServer was not provided an SSL certificate and
+            defaults back to self-signed SSL keys.
+        show_motd
+            If a Message-of-the-Day is available, display it
+        cache_max_size
+            Maximum size of the cache directory
+        """
+        super().__init__(
+            address,
+            username=username,
+            password=password,
+            verify=verify,
+            show_motd=show_motd,
+            cache_dir=cache_dir,
+            cache_max_size=cache_max_size,
+            memory_cache_key=memory_cache_key,
+        )
         self.record_cache = RecordCache(
             os.path.join(self.cache.cache_dir, "cache.sqlite"), read_only=False
         )

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -5,6 +5,21 @@ from openff.toolkit.utils.toolkits import (
     RDKitToolkitWrapper,
     UndefinedStereochemistryError,
 )
+from qcportal import PortalClient
+from qcportal.cache import RecordCache
+
+
+def client_record_cache(client: PortalClient) -> bool:
+    """Initialize a RecordCache stored on `client` if the client already has a
+    cache_dir. Returns whether or not this was the case (whether caching should
+    be used)
+
+    """
+    if client.cache and client.cache.cache_dir:
+        if not hasattr(client, "record_cache"):
+            client.record_cache = RecordCache(client.cache.cache_dir, read_only=False)
+        return True
+    return False
 
 
 def get_data(relative_path):

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -82,6 +82,19 @@ class CachedPortalClient(PortalClient):
             os.path.join(self.cache.cache_dir, "cache.sqlite"), read_only=False
         )
 
+    def __repr__(self) -> str:
+        """A short representation of the current PortalClient.
+
+        Returns
+        -------
+        str
+            The desired representation.
+        """
+        ret = "CachedPortalClient(server_name='{}', address='{}', username='{}', cache_dir='{}')".format(
+            self.server_name, self.address, self.username, self.cache.cache_dir
+        )
+        return ret
+
     def get_optimizations(
         self,
         record_ids: Union[int, Sequence[int]],

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -26,8 +26,6 @@ from qcportal.torsiondrive.record_models import TorsiondriveRecord
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_CACHE_DIR = "./qcsubmit_qcportal_cache"
-
 
 class CachedPortalClient(PortalClient):
     """A cached version of a `qcportal.PortalClient
@@ -250,7 +248,7 @@ class CachedPortalClient(PortalClient):
 
 
 def _default_portal_client(client_address) -> PortalClient:
-    return CachedPortalClient(client_address, cache_dir=_DEFAULT_CACHE_DIR)
+    return PortalClient(client_address)
 
 
 @contextmanager

--- a/openff/qcsubmit/utils/utils.py
+++ b/openff/qcsubmit/utils/utils.py
@@ -45,8 +45,9 @@ class CachedPortalClient(PortalClient):
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if not isinstance(record_ids, Sequence):
+            unpack = True
             record_ids = [record_ids]
-        return get_records_with_cache(
+        res = get_records_with_cache(
             client=self,
             record_cache=self.record_cache,
             record_type=OptimizationRecord,
@@ -54,6 +55,10 @@ class CachedPortalClient(PortalClient):
             include=include,
             force_fetch=False,
         )
+        if unpack:
+            return res[0]
+        else:
+            return res
 
     def get_singlepoints(
         self,
@@ -65,8 +70,9 @@ class CachedPortalClient(PortalClient):
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if not isinstance(record_ids, Sequence):
+            unpack = True
             record_ids = [record_ids]
-        return get_records_with_cache(
+        res = get_records_with_cache(
             client=self,
             record_cache=self.record_cache,
             record_type=SinglepointRecord,
@@ -74,6 +80,10 @@ class CachedPortalClient(PortalClient):
             include=include,
             force_fetch=False,
         )
+        if unpack:
+            return res[0]
+        else:
+            return res
 
     def get_torsiondrives(
         self,
@@ -85,8 +95,9 @@ class CachedPortalClient(PortalClient):
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if not isinstance(record_ids, Sequence):
+            unpack = True
             record_ids = [record_ids]
-        return get_records_with_cache(
+        res = get_records_with_cache(
             client=self,
             record_cache=self.record_cache,
             record_type=TorsiondriveRecord,
@@ -94,6 +105,10 @@ class CachedPortalClient(PortalClient):
             include=include,
             force_fetch=False,
         )
+        if unpack:
+            return res[0]
+        else:
+            return res
 
     def get_molecules(
         self,
@@ -103,8 +118,9 @@ class CachedPortalClient(PortalClient):
         if missing_ok:
             logger.warning("missing_ok provided but unused by CachedPortalClient")
         if not isinstance(molecule_ids, Sequence):
+            unpack = True
             molecule_ids = [molecule_ids]
-        return get_records_with_cache(
+        res = get_records_with_cache(
             client=self,
             record_cache=self.record_cache,
             record_type=Molecule,
@@ -112,6 +128,10 @@ class CachedPortalClient(PortalClient):
             include=None,
             force_fetch=False,
         )
+        if unpack:
+            return res[0]
+        else:
+            return res
 
 
 def _default_portal_client(client_address) -> PortalClient:


### PR DESCRIPTION
## Description
This PR uses the [get_records_with_cache](https://github.com/MolSSI/QCFractal/blob/5e35393e150fb67a528f26549b6f9ea3bc68c186/qcportal/qcportal/cache.py#L590) function discussed in our last QCArchive meeting to cache `to_records` calls automatically. With these changes alone, users cannot actually access this behavior, but when combined with #284, it enables code like this:

```python
from qcportal import PortalClient

from openff.qcsubmit._tests.utils.test_manager import no_internet
from openff.qcsubmit.results import OptimizationResultCollection
from openff.qcsubmit.utils.utils import portal_client_manager

opt = OptimizationResultCollection.parse_file("tiny-opt-dataset.json")
client = PortalClient("https://api.qcarchive.molssi.org:443", cache_dir=".")

with portal_client_manager(lambda _: client):
    print(len(opt.to_records()))
    with no_internet():
        print(len(opt.to_records()))
```

For this PR, I applied the changes separately from #284 to the main branch, but I have used this code to test the combined changes locally, and it works! I have not run into MolSSI/QCFractal#844 here yet, so hopefully that is less common in real use cases.

## Todos
  - [x] Enable caching for expensive `to_records` calls
  - [x] Probably wait for #284. This isn't really useful on its own, but I was excited to get a proof of concept working, and I think both changes are actually needed for either one to help my valence fits

## Status
- [ ] Ready to go