### PR TITLE
Add RECAP fragmentation

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -20,6 +20,7 @@ Releases are given with dates in DD-MM-YYYY format.
 ### New Features
 
 * [PR #284:] Add `portal_client_manager` for using custom `PortalClient` settings
+* [PR #289:] Add `workflow_components.RECAPFragmenter` to fragment molecules using the rdkit implementation of RECAP [@jthorton]
 
 ## 0.51.0 / 23-04-2024
 
@@ -137,6 +138,7 @@ For more information on this release, see https://github.com/openforcefield/open
 [PR #283:]: https://github.com/openforcefield/openff-qcsubmit/pull/283
 [PR #284:]: https://github.com/openforcefield/openff-qcsubmit/pull/284
 [PR #285:]: https://github.com/openforcefield/openff-qcsubmit/pull/285
+[PR #289:]: https://github.com/openforcefield/openff-qcsubmit/pull/289
 
 [@jthorton]: https://github.com/jthorton
 [@dotsdl]: https://github.com/dotsdl

--- a/openff/qcsubmit/_tests/test_workflow_components.py
+++ b/openff/qcsubmit/_tests/test_workflow_components.py
@@ -821,6 +821,26 @@ def test_pfizer_fragmentation_apply():
         assert "dihedrals" in molecule.properties
 
 
+def test_recap_fragmentation_apply():
+    """Make sure we can use the recap fragmentation method and that it does not tag bonds."""
+
+    fragmenter = workflow_components.RECAPFragmenter()
+    assert fragmenter.is_available()
+    # try running the example from the rdkit docs
+    molecule = Molecule.from_smiles("C1CC1Oc1ccccc1-c1ncc(OC)cc1")
+    result = fragmenter.apply(molecules=[molecule], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
+    assert result.n_molecules == 3
+    for molecule in result.molecules:
+        assert "dihedrals" not in molecule.properties
+    # make sure we have the correct set of molecules
+    expected_molecules = [
+        Molecule.from_smiles("C1CC1"),
+        Molecule.from_smiles("c1ccccc1"),
+        Molecule.from_smiles("COc1cccnc1")
+    ]
+    assert list(result.molecules) == expected_molecules
+
+
 def test_rotor_filter_maximum():
     """
     Remove molecules with too many rotatable bonds.

--- a/openff/qcsubmit/_tests/test_workflow_components.py
+++ b/openff/qcsubmit/_tests/test_workflow_components.py
@@ -840,7 +840,7 @@ def test_recap_fragmentation_apply():
         Molecule.from_smiles("c1ccccc1"),
         Molecule.from_smiles("COc1cccnc1"),
     ]
-    assert list(result.molecules) == expected_molecules
+    assert set(list(result.molecules)) == set(expected_molecules)
 
 
 def test_rotor_filter_maximum():

--- a/openff/qcsubmit/_tests/test_workflow_components.py
+++ b/openff/qcsubmit/_tests/test_workflow_components.py
@@ -828,7 +828,9 @@ def test_recap_fragmentation_apply():
     assert fragmenter.is_available()
     # try running the example from the rdkit docs
     molecule = Molecule.from_smiles("C1CC1Oc1ccccc1-c1ncc(OC)cc1")
-    result = fragmenter.apply(molecules=[molecule], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY)
+    result = fragmenter.apply(
+        molecules=[molecule], processors=1, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
+    )
     assert result.n_molecules == 3
     for molecule in result.molecules:
         assert "dihedrals" not in molecule.properties
@@ -836,7 +838,7 @@ def test_recap_fragmentation_apply():
     expected_molecules = [
         Molecule.from_smiles("C1CC1"),
         Molecule.from_smiles("c1ccccc1"),
-        Molecule.from_smiles("COc1cccnc1")
+        Molecule.from_smiles("COc1cccnc1"),
     ]
     assert list(result.molecules) == expected_molecules
 

--- a/openff/qcsubmit/workflow_components/__init__.py
+++ b/openff/qcsubmit/workflow_components/__init__.py
@@ -24,8 +24,8 @@ from openff.qcsubmit.workflow_components.filters import (
 )
 from openff.qcsubmit.workflow_components.fragmentation import (
     PfizerFragmenter,
-    WBOFragmenter,
     RECAPFragmenter,
+    WBOFragmenter,
 )
 from openff.qcsubmit.workflow_components.state_enumeration import (
     EnumerateProtomers,

--- a/openff/qcsubmit/workflow_components/__init__.py
+++ b/openff/qcsubmit/workflow_components/__init__.py
@@ -25,6 +25,7 @@ from openff.qcsubmit.workflow_components.filters import (
 from openff.qcsubmit.workflow_components.fragmentation import (
     PfizerFragmenter,
     WBOFragmenter,
+    RECAPFragmenter,
 )
 from openff.qcsubmit.workflow_components.state_enumeration import (
     EnumerateProtomers,
@@ -62,6 +63,7 @@ __all__ = [
     "SmartsFilter",
     "PfizerFragmenter",
     "WBOFragmenter",
+    "RECAPFragmenter",
     "EnumerateProtomers",
     "EnumerateStereoisomers",
     "EnumerateTautomers",

--- a/openff/qcsubmit/workflow_components/base.py
+++ b/openff/qcsubmit/workflow_components/base.py
@@ -24,8 +24,8 @@ from openff.qcsubmit.workflow_components.filters import (
 )
 from openff.qcsubmit.workflow_components.fragmentation import (
     PfizerFragmenter,
-    WBOFragmenter,
     RECAPFragmenter,
+    WBOFragmenter,
 )
 from openff.qcsubmit.workflow_components.state_enumeration import (
     EnumerateProtomers,

--- a/openff/qcsubmit/workflow_components/base.py
+++ b/openff/qcsubmit/workflow_components/base.py
@@ -25,6 +25,7 @@ from openff.qcsubmit.workflow_components.filters import (
 from openff.qcsubmit.workflow_components.fragmentation import (
     PfizerFragmenter,
     WBOFragmenter,
+    RECAPFragmenter,
 )
 from openff.qcsubmit.workflow_components.state_enumeration import (
     EnumerateProtomers,
@@ -54,6 +55,7 @@ Components = Union[
     EnumerateStereoisomers,
     WBOFragmenter,
     PfizerFragmenter,
+    RECAPFragmenter,
     ChargeFilter,
     ScanFilter,
     ScanEnumerator,
@@ -159,6 +161,7 @@ register_component(StandardConformerGenerator)
 # fragmentation
 register_component(WBOFragmenter)
 register_component(PfizerFragmenter)
+register_component(RECAPFragmenter)
 
 # filters
 register_component(RotorFilter)

--- a/openff/qcsubmit/workflow_components/fragmentation.py
+++ b/openff/qcsubmit/workflow_components/fragmentation.py
@@ -2,7 +2,7 @@
 Components that aid with Fragmentation of molecules.
 """
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Literal
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional
 
 from openff.toolkit import Molecule
 from openff.toolkit.utils import ToolkitRegistry
@@ -257,7 +257,7 @@ class RECAPFragmenter(ToolkitValidator, CustomWorkflowComponent):
             raise_error=True,
             return_bool=True,
             package="rdkit",
-            raise_msg="Please install via `mamba install rdkit -c conda-forge`."
+            raise_msg="Please install via `mamba install rdkit -c conda-forge`.",
         )
         return rdkit
 
@@ -272,7 +272,7 @@ class RECAPFragmenter(ToolkitValidator, CustomWorkflowComponent):
             <https://github.com/SimonBoothroyd/gnn-charge-models/blob/ee02a4426eb14c48bfb30c9894af267510efcac0/data-set-curation/generate-fragments.py>
         """
         from rdkit import Chem
-        from rdkit.Chem import Recap, Descriptors, AllChem
+        from rdkit.Chem import AllChem, Descriptors, Recap
 
         result = self._create_result(toolkit_registry=toolkit_registry)
 

--- a/openff/qcsubmit/workflow_components/fragmentation.py
+++ b/openff/qcsubmit/workflow_components/fragmentation.py
@@ -303,6 +303,10 @@ class RECAPFragmenter(ToolkitValidator, CustomWorkflowComponent):
                     # if the fragment is radical skip it
                     continue
 
-                result.add_molecule(molecule=Molecule.from_rdkit(rd_fragment, allow_undefined_stereo=True))
+                result.add_molecule(
+                    molecule=Molecule.from_rdkit(
+                        rd_fragment, allow_undefined_stereo=True
+                    )
+                )
 
         return result

--- a/openff/qcsubmit/workflow_components/fragmentation.py
+++ b/openff/qcsubmit/workflow_components/fragmentation.py
@@ -303,6 +303,6 @@ class RECAPFragmenter(ToolkitValidator, CustomWorkflowComponent):
                     # if the fragment is radical skip it
                     continue
 
-                result.add_molecule(molecule=Molecule.from_rdkit(rd_fragment))
+                result.add_molecule(molecule=Molecule.from_rdkit(rd_fragment, allow_undefined_stereo=True))
 
         return result


### PR DESCRIPTION
## Description
This PR adds a new workflow component to perform fragmentation using the RECAP method implemented in RDkit. This has been used in the past [ESP datasets](https://github.com/openforcefield/qca-dataset-submission/blob/master/submissions/2022-01-16-OpenFF-ESP-Fragment-Conformers-v1.0/README.md) and will be used in newly generated ones so having formal support should make dataset curations scripts simpler and reproducible. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] add tests

## Questions
- [ ] Question1

## Status
- [x] Ready to go