### PR TITLE
Re-enable codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,5 +83,6 @@ jobs:
       - name: Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true


### PR DESCRIPTION
Based on the CI errors, I think we're just missing the token. I also changed `fail_ci_if_error` to `true` in-line with the toolkit repo.

## Description
Enable codecov coverage checks in CI. There was already a step in CI.yml for this, but no token was being provided and `fail_ci_if_error` was `false`, so it was silently failing each time.

## Status
- [ ] Ready to go