### PR TITLE
Fix tests by pulling down more recent `apsw`

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -50,3 +50,6 @@ dependencies:
   # Optional
   - openmmforcefields
   - openff-fragmenter-base >=0.2.0
+
+  # Shim for QCFractal deployment issues
+  - apsw >=3.42

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -51,3 +51,6 @@ dependencies:
   - pint=0.21
   - openff-units=0.2.1
   - postgresql
+
+  # Shim for QCFractal deployment issues
+  - apsw >=3.42


### PR DESCRIPTION
## Description
Old versions of `apsw` (i.e. 3.39.2.1  from earlier today) are pulled down by testing environments but [QCFractal needs newer versions](https://github.com/conda-forge/qcfractal-feedstock/pull/52/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aL51) like 3.42+. This patch fixes the test environment.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Fix `apsw` constraint from upstream

## Status
- [ ] Ready to go