### PR TITLE
Update `OptimizationResultCollection.create_basic_dataset` to preserve molecule IDs

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,6 +15,7 @@ Releases are given with dates in DD-MM-YYYY format.
 
 ### Bugfixes
 * [PR #300:] Fixes [an issue](https://github.com/openforcefield/openff-qcsubmit/issues/299) where methods to retrieve `BasicResultCollection` and `OptimizationResultCollection` objects from QCArchive would crash if an entry was missing a CMILES.
+* [PR #303:] Fixes [an issue](https://github.com/openforcefield/openff-qcsubmit/issues/297) where `OptimizationResultCollection.create_basic_dataset` was not reusing molecule IDs from QCArchive.
 
 
 ## 0.53.0 / 12-8-2024
@@ -161,6 +162,7 @@ For more information on this release, see https://github.com/openforcefield/open
 [PR #290:]: https://github.com/openforcefield/openff-qcsubmit/pull/290
 [PR #294:]: https://github.com/openforcefield/openff-qcsubmit/pull/294
 [PR #300:]: https://github.com/openforcefield/openff-qcsubmit/pull/300
+[PR #303:]: https://github.com/openforcefield/openff-qcsubmit/pull/303
 
 [@jthorton]: https://github.com/jthorton
 [@dotsdl]: https://github.com/dotsdl

--- a/openff/qcsubmit/_tests/results/__init__.py
+++ b/openff/qcsubmit/_tests/results/__init__.py
@@ -26,20 +26,6 @@ from openff.qcsubmit.results.results import _BaseResult
 class _PortalClient(BaseModel):
     address: str
 
-    def get_molecules(self, *args):
-        """This is needed by ``test_optimization_create_basic_dataset`` because
-        ``create_basic_dataset`` now accesses the ``final_molecule`` property
-        of the ``OptimizationRecord`` instances, which can attempt to fetch
-        molecules from the QCArchive server.
-
-        pydantic does a lot of validation along the way, so trying to return
-        empty qcelemental Molecules or Molecules without conformers doesn't
-        work.
-        """
-        mol = Molecule.from_smiles("C")
-        mol.generate_conformers(n_conformers=1)
-        return [mol.to_qcschema()]
-
 
 def _mock_molecule(entry: _BaseResult, n_conformers: int = 1) -> Molecule:
     molecule: Molecule = Molecule.from_smiles(entry.cmiles)

--- a/openff/qcsubmit/_tests/results/__init__.py
+++ b/openff/qcsubmit/_tests/results/__init__.py
@@ -26,6 +26,20 @@ from openff.qcsubmit.results.results import _BaseResult
 class _PortalClient(BaseModel):
     address: str
 
+    def get_molecules(self, *args):
+        """This is needed by ``test_optimization_create_basic_dataset`` because
+        ``create_basic_dataset`` now accesses the ``final_molecule`` property
+        of the ``OptimizationRecord`` instances, which can attempt to fetch
+        molecules from the QCArchive server.
+
+        pydantic does a lot of validation along the way, so trying to return
+        empty qcelemental Molecules or Molecules without conformers doesn't
+        work.
+        """
+        mol = Molecule.from_smiles("C")
+        mol.generate_conformers(n_conformers=1)
+        return [mol.to_qcschema()]
+
 
 def _mock_molecule(entry: _BaseResult, n_conformers: int = 1) -> Molecule:
     molecule: Molecule = Molecule.from_smiles(entry.cmiles)

--- a/openff/qcsubmit/_tests/results/test_results.py
+++ b/openff/qcsubmit/_tests/results/test_results.py
@@ -382,8 +382,9 @@ def test_optimization_create_basic_dataset(optimization_result_collection):
 
 
 def test_optimization_create_basic_dataset_297(public_client):
-    """
-    Test creating a new ``BasicDataset`` from the result of an optimization dataset.
+    """Test creating a new ``BasicDataset`` from the result of an optimization
+    dataset, and verify that the molecule hashes match to prevent the creation
+    of separate records on QCArchive. See issue #297 for more details.
     """
 
     opt = OptimizationResultCollection.from_server(

--- a/openff/qcsubmit/_tests/results/test_results.py
+++ b/openff/qcsubmit/_tests/results/test_results.py
@@ -381,16 +381,39 @@ def test_optimization_create_basic_dataset(optimization_result_collection):
     assert dataset.n_records == 5  # the collection contains 1 duplicate
 
 
-def test_optimization_create_basic_dataset_297(public_client):
+def test_optimization_create_basic_dataset_297():
     """Test creating a new ``BasicDataset`` from the result of an optimization
     dataset, and verify that the molecule hashes match to prevent the creation
     of separate records on QCArchive. See issue #297 for more details.
     """
 
-    opt = OptimizationResultCollection.from_server(
-        public_client,
-        datasets=["OpenFF Sulfur Optimization Training Coverage Supplement v1.0"],
-        spec_name="default",
+    # these are two real entries from the "OpenFF Sulfur Optimization Training
+    # Coverage Supplement v1.0" dataset used in issue #297. the first fails the
+    # round-trip in the previous create_basic_dataset implemenation but the
+    # second works with either
+    opt = OptimizationResultCollection.parse_raw(
+        """
+        {
+            "entries": {
+                "https://api.qcarchive.molssi.org:443/": [
+                {
+                    "type": "optimization",
+                    "record_id": 138340682,
+                    "cmiles": "[H:11][c:10]1[c:12]([c:14]([c:16]2[c:7]([c:8]1[H:9])[C:5](=[O:6])[C:3](=[C:1]([S:17]2(=[O:18])=[O:19])[H:2])[Br:4])[H:15])[H:13]",
+                    "inchi_key": "UKQYACGPJCUZJN-UHFFFAOYNA-N"
+                },
+                {
+                    "type": "optimization",
+                    "record_id": 138341382,
+                    "cmiles": "[H:18][C@@:10]([C:11](=[O:12])[O:13][H:14])([C:9]([H:19])([H:20])[C:8]([H:21])([H:22])[S:2](=[N:1][H:23])(=[O:3])[C:4]([H:5])([H:6])[H:7])[N:15]([H:16])[H:17]",
+                    "inchi_key": "SXTAYKAGBXMACB-AIXGRKOHNA-N"
+                }
+                ]
+            },
+            "provenance": {},
+            "type": "OptimizationResultCollection"
+        }
+        """
     )
 
     opt_hashes = {rec.final_molecule.get_hash() for rec, _mol in opt.to_records()}

--- a/openff/qcsubmit/_tests/results/test_results.py
+++ b/openff/qcsubmit/_tests/results/test_results.py
@@ -359,38 +359,16 @@ def test_to_records(
         assert molecule.n_conformers == 1
 
 
-def test_optimization_create_basic_dataset(optimization_result_collection):
-    """
-    Test creating a new ``BasicDataset`` from the result of an optimization dataset.
-    """
-
-    dataset = optimization_result_collection.create_basic_dataset(
-        dataset_name="new basicdataset",
-        description="test new optimizationdataset",
-        tagline="new optimization dataset",
-        driver="energy",
-        qc_specifications=[QCSpec(spec_name="some-name", basis="6-31G")],
-    )
-
-    assert len(dataset.qc_specifications) == 1
-    assert {*dataset.qc_specifications} == {"some-name"}
-    assert dataset.qc_specifications["some-name"].basis == "6-31G"
-
-    assert dataset.dataset_name == "new basicdataset"
-    assert dataset.n_molecules == 4
-    assert dataset.n_records == 5  # the collection contains 1 duplicate
-
-
-def test_optimization_create_basic_dataset_297():
+def test_optimization_create_basic_dataset():
     """Test creating a new ``BasicDataset`` from the result of an optimization
     dataset, and verify that the molecule hashes match to prevent the creation
     of separate records on QCArchive. See issue #297 for more details.
     """
 
-    # these are two real entries from the "OpenFF Sulfur Optimization Training
-    # Coverage Supplement v1.0" dataset used in issue #297. the first fails the
-    # round-trip in the previous create_basic_dataset implemenation but the
-    # second works with either
+    # these are three real entries from the "OpenFF Sulfur Optimization
+    # Training Coverage Supplement v1.0" dataset used in issue #297. the first
+    # fails the round-trip in the previous create_basic_dataset implemenation
+    # but the next two work with either
     opt = OptimizationResultCollection.parse_raw(
         """
         {
@@ -405,6 +383,12 @@ def test_optimization_create_basic_dataset_297():
                 {
                     "type": "optimization",
                     "record_id": 138341382,
+                    "cmiles": "[H:18][C@@:10]([C:11](=[O:12])[O:13][H:14])([C:9]([H:19])([H:20])[C:8]([H:21])([H:22])[S:2](=[N:1][H:23])(=[O:3])[C:4]([H:5])([H:6])[H:7])[N:15]([H:16])[H:17]",
+                    "inchi_key": "SXTAYKAGBXMACB-AIXGRKOHNA-N"
+                },
+                {
+                    "type": "optimization",
+                    "record_id": 138341384,
                     "cmiles": "[H:18][C@@:10]([C:11](=[O:12])[O:13][H:14])([C:9]([H:19])([H:20])[C:8]([H:21])([H:22])[S:2](=[N:1][H:23])(=[O:3])[C:4]([H:5])([H:6])[H:7])[N:15]([H:16])[H:17]",
                     "inchi_key": "SXTAYKAGBXMACB-AIXGRKOHNA-N"
                 }
@@ -423,15 +407,26 @@ def test_optimization_create_basic_dataset_297():
         "descdesc",
         "tagtagtag",
         driver="hessian",
+        qc_specifications=[QCSpec(spec_name="some-name", basis="6-31G")],
     )
 
     bas_hashes = {mol.molecule.get_hash() for mol in basic._get_entries()}
 
     n_results = opt.n_results
 
+    # check for molecule agreement between optimization and basic datasets
     assert len(opt_hashes) == n_results
     assert len(bas_hashes) == n_results
     assert len(opt_hashes & bas_hashes) == n_results
+
+    # check general basic dataset construction
+    assert len(basic.qc_specifications) == 1
+    assert {*basic.qc_specifications} == {"some-name"}
+    assert basic.qc_specifications["some-name"].basis == "6-31G"
+
+    assert basic.dataset_name == "dummy basic dataset name"
+    assert basic.n_molecules == 2
+    assert basic.n_records == 3  # the collection contains 1 duplicate
 
 
 def test_optimization_to_basic_result_collection(public_client):

--- a/openff/qcsubmit/_tests/results/test_results.py
+++ b/openff/qcsubmit/_tests/results/test_results.py
@@ -367,7 +367,7 @@ def test_optimization_create_basic_dataset():
 
     # these are three real entries from the "OpenFF Sulfur Optimization
     # Training Coverage Supplement v1.0" dataset used in issue #297. the first
-    # fails the round-trip in the previous create_basic_dataset implemenation
+    # fails the round-trip in the previous create_basic_dataset implementation
     # but the next two work with either
     opt = OptimizationResultCollection.parse_raw(
         """

--- a/openff/qcsubmit/_tests/results/test_results.py
+++ b/openff/qcsubmit/_tests/results/test_results.py
@@ -381,6 +381,35 @@ def test_optimization_create_basic_dataset(optimization_result_collection):
     assert dataset.n_records == 5  # the collection contains 1 duplicate
 
 
+def test_optimization_create_basic_dataset_297(public_client):
+    """
+    Test creating a new ``BasicDataset`` from the result of an optimization dataset.
+    """
+
+    opt = OptimizationResultCollection.from_server(
+        public_client,
+        datasets=["OpenFF Sulfur Optimization Training Coverage Supplement v1.0"],
+        spec_name="default",
+    )
+
+    opt_hashes = {rec.final_molecule.get_hash() for rec, _mol in opt.to_records()}
+
+    basic = opt.create_basic_dataset(
+        "dummy basic dataset name",
+        "descdesc",
+        "tagtagtag",
+        driver="hessian",
+    )
+
+    bas_hashes = {mol.molecule.get_hash() for mol in basic._get_entries()}
+
+    n_results = opt.n_results
+
+    assert len(opt_hashes) == n_results
+    assert len(bas_hashes) == n_results
+    assert len(opt_hashes & bas_hashes) == n_results
+
+
 def test_optimization_to_basic_result_collection(public_client):
     optimization_result_collection = OptimizationResultCollection.from_server(
         public_client, ["OpenFF Gen 2 Opt Set 3 Pfizer Discrepancy"]

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -689,7 +689,8 @@ class OptimizationResultCollection(_BaseResultCollection):
                 index=base_molecule.to_smiles(
                     isomeric=True, explicit_hydrogens=False, mapped=False
                 ),
-                molecule=base_molecule,
+                molecule=None,
+                initial_molecules=[rec.final_molecule for rec, _ in records],
                 attributes=MoleculeAttributes.from_openff_molecule(base_molecule),
                 extras=base_record.extras,
                 keywords=base_record.specification.keywords,


### PR DESCRIPTION
## Description
The goal of this PR is a long-term fix to #297. In short, the current `OptimizationResultCollection.create_basic_dataset` implementation creates a new dataset by round-tripping through OpenFF `Molecule`s, which causes issues with the hashing/equivalence checks in QCArchive, leading to "the same molecules" being considered different. In turn, this causes `OptimizationResultCollection.to_basic_result_collection` to return fewer records than expected.

Earlier qca-dataset-submissions ([example](https://github.com/openforcefield/qca-dataset-submission/blob/95809b4d5a98a118e340b393fdd3636ad24a8606/submissions/2019-07-05%20OpenFF%20NCI250K%20Boron%201/04_create_hessian_dataset.py#L4)) manually constructed qcportal datasets instead of using qcsubmit datasets to avoid this round trip. Due to the major updates to qcportal, I don't think this code works anymore, and it seems much more ergonomic to handle this in create_basic_dataset anyway.

The fix is simply to pass qcelemental `Molecule` objects along directly instead of reconstructing OpenFF `Molecule`s. As it turns out, this was essentially already built into qcsubmit and just required a two-line change to update some keyword arguments in the `BasicDataset.add_molecule` call.

## Todos

  - [x] Update `create_basic_dataset` to preserve molecule hashes from the optimization dataset

## Status
- [x] Ready to go