### PR TITLE
Drop use of `defaults` conda channel

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -3,7 +3,6 @@ name: qcsubmit-test-basic
 channels:
   - openeye
   - conda-forge
-  - defaults
 
 dependencies:
 


### PR DESCRIPTION
## Description
We don't need this:

```
$ micromamba create --file devtools/conda-envs/basic.yaml
conda-forge/noarch                                          Using cache
conda-forge/osx-arm64                                       Using cache
warning  libmamba 'repo.anaconda.com', a commercial channel hosted by Anaconda.com, is used.

warning  libmamba Please make sure you understand Anaconda Terms of Services.

warning  libmamba See: https://legal.anaconda.com/policies/en/
warning  libmamba 'repo.anaconda.com', a commercial channel hosted by Anaconda.com, is used.

warning  libmamba Please make sure you understand Anaconda Terms of Services.

warning  libmamba See: https://legal.anaconda.com/policies/en/
warning  libmamba 'repo.anaconda.com', a commercial channel hosted by Anaconda.com, is used.

warning  libmamba Please make sure you understand Anaconda Terms of Services.

warning  libmamba See: https://legal.anaconda.com/policies/en/
warning  libmamba 'repo.anaconda.com', a commercial channel hosted by Anaconda.com, is used.

warning  libmamba Please make sure you understand Anaconda Terms of Services.

warning  libmamba See: https://legal.anaconda.com/policies/en/

```

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Drop use of `defaults` conda channel

## Status
- [x] Ready to go