### PR TITLE
Converge maxiter

### DIFF
--- a/openff/qcsubmit/_tests/test_submissions.py
+++ b/openff/qcsubmit/_tests/test_submissions.py
@@ -842,22 +842,17 @@ def test_optimization_submission_custom_convergence(fulltest_client):
 
     client = fulltest_client
 
-    qc_spec, driver = specification
-    program = qc_spec["program"]
-    if not has_program(program):
-        pytest.skip(f"Program '{program}' not found.")
-
     molecules = Molecule.from_file(get_data("butane_conformers.pdb"), "pdb")
 
-    factory = OptimizationDatasetFactory(driver=driver)
+    factory = OptimizationDatasetFactory(driver='gradient')
 
     dataset = factory.create_dataset(
-        dataset_name=f"Test optimizations info {program}, {driver} with custom convergence set",
+        dataset_name=f"Test optimizations with custom convergence set",
         molecules=molecules[:2],
         description="Test optimization dataset with custom convergence set",
         tagline="Testing optimization datasets with custom convergence set",
     )
-    # add just mm spec
+    # add spec
     dataset.add_qc_spec(
         method="hf",
         basis="sto-3g",

--- a/openff/qcsubmit/_tests/test_submissions.py
+++ b/openff/qcsubmit/_tests/test_submissions.py
@@ -847,7 +847,7 @@ def test_optimization_submission_custom_convergence(fulltest_client):
     factory = OptimizationDatasetFactory(driver="gradient")
 
     dataset = factory.create_dataset(
-        dataset_name=f"Test optimizations with custom convergence set",
+        dataset_name="Test optimizations with custom convergence set",
         molecules=molecules[:2],
         description="Test optimization dataset with custom convergence set",
         tagline="Testing optimization datasets with custom convergence set",
@@ -922,11 +922,6 @@ def test_optimization_submission_custom_convergence(fulltest_client):
 
             # Length of trajectory is the number of steps. Should be equal to maxiter
             assert len(record.trajectory) == dataset.optimization_procedure.maxiter
-            # if we used psi4 make sure the properties were captured
-            if program == "psi4":
-                result = record.trajectory[0]
-                assert "current dipole" in result.properties.keys()
-                assert "scf quadrupole" in result.properties.keys()
 
 
 @pytest.mark.xfail(

--- a/openff/qcsubmit/_tests/test_submissions.py
+++ b/openff/qcsubmit/_tests/test_submissions.py
@@ -844,7 +844,7 @@ def test_optimization_submission_custom_convergence(fulltest_client):
 
     molecules = Molecule.from_file(get_data("butane_conformers.pdb"), "pdb")
 
-    factory = OptimizationDatasetFactory(driver='gradient')
+    factory = OptimizationDatasetFactory(driver="gradient")
 
     dataset = factory.create_dataset(
         dataset_name=f"Test optimizations with custom convergence set",

--- a/openff/qcsubmit/_tests/test_submissions.py
+++ b/openff/qcsubmit/_tests/test_submissions.py
@@ -852,13 +852,13 @@ def test_optimization_submission_custom_convergence(fulltest_client):
         description="Test optimization dataset with custom convergence set",
         tagline="Testing optimization datasets with custom convergence set",
     )
-    # add spec
+    # add just mm spec
     dataset.add_qc_spec(
-        method="hf",
-        basis="sto-3g",
-        program="psi4",
-        spec_name="hf_sto3g",
-        spec_description="hf/sto-3g",
+        method="openff-1.0.0",
+        basis="smirnoff",
+        program="openmm",
+        spec_name="default",
+        spec_description="mm default spec",
         overwrite=True,
     )
 

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -1016,6 +1016,17 @@ class OptimizationDataset(BasicDataset):
     def _get_specifications(self) -> Dict[str, OptimizationSpecification]:
         opt_kw = self.optimization_procedure.get_optimzation_keywords()
 
+        # Handle custom convergence set dictionary
+        if type(opt_kw['convergence_set']) == dict:
+            convergence_set_string = ''
+            for key in opt_kw['convergence_set'].keys():
+                if key.lower() == 'maxiter':
+                    convergence_set_string += key.lower()
+                else:
+                    convergence_set_string += " {} {} ".format(key.lower(), str(opt_kw['convergence_set'][key]))
+            opt_kw['convergence_set'] = convergence_set_string
+
+
         ret = {}
 
         for spec_name, spec in self.qc_specifications.items():

--- a/openff/qcsubmit/datasets/datasets.py
+++ b/openff/qcsubmit/datasets/datasets.py
@@ -1016,17 +1016,6 @@ class OptimizationDataset(BasicDataset):
     def _get_specifications(self) -> Dict[str, OptimizationSpecification]:
         opt_kw = self.optimization_procedure.get_optimzation_keywords()
 
-        # Handle custom convergence set dictionary
-        if type(opt_kw['convergence_set']) == dict:
-            convergence_set_string = ''
-            for key in opt_kw['convergence_set'].keys():
-                if key.lower() == 'maxiter':
-                    convergence_set_string += key.lower()
-                else:
-                    convergence_set_string += " {} {} ".format(key.lower(), str(opt_kw['convergence_set'][key]))
-            opt_kw['convergence_set'] = convergence_set_string
-
-
         ret = {}
 
         for spec_name, spec in self.qc_specifications.items():

--- a/openff/qcsubmit/procedures.py
+++ b/openff/qcsubmit/procedures.py
@@ -45,28 +45,20 @@ class GeometricProcedure(BaseModel):
             | `GAU_VERYTIGHT`   | Gaussian very tight | 1e-6   | 1e-6    | 2e-6   | 4e-6   | 6e-6  |
             +-------------------+---------------------+--------+---------+--------+--------+-------+
 
-        One can also request custom convergence criteria using a dictionary with the following format:
+        One can also request custom convergence criteria by passing `convergence_set` a string with the following format:
 
-           {'energy': 1e-6,
-            'grms': 3e-4,
-            'gmax': 4.5e-4,
-            'drms': 1.2e-3,
-            'dmax': 1.8e-3 }
+           'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3'
 
             Note that the units are Hartrees for energy and Bohr for distances. 
 
             It is also possible to request that the optimization exit 
             gracefully after hitting the maximum number of iterations by including 
-            an additional `maxiter` key to the `convergence_set` dictionary as follows:
+            an optional `maxiter` flag to the end of the string:
             
-            {'energy': 1e-6,
-             'grms': 3e-4,
-             'gmax': 4.5e-4,
-             'drms': 1.2e-3,
-             'dmax': 1.8e-3
-             'maxiter': '' }
+            'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 maxiter'
 
-            Note that the entry corresponding to the `maxiter` key will be ignored. 
+            This can be used to run a few optimization steps to partially relax a molecule and eliminate high forces.
+            Nothing should follow the `maxiter` flag specified here in `convergence_set`. 
             To specify the maximum number of iterations, please use the separate `maxiter` _keyword_.
     """
 
@@ -99,16 +91,7 @@ class GeometricProcedure(BaseModel):
     trust: float = Field(0.1, description="Starting value of the trust radius.")
     tmax: float = Field(0.3, description="Maximum value of trust radius.")
     maxiter: int = Field(300, description="Maximum number of optimization cycles.")
-    convergence_set: Union[Literal[
-        "GAU",
-        "NWCHEM_LOOSE",
-        "GAU_LOOSE",
-        "TURBOMOLE",
-        "INTERFRAG_TIGHT",
-        "GAU_TIGHT",
-        "GAU_VERYTIGHT",
-        "TEST"
-    ],Dict] = Field(
+    convergence_set: str = Field(
         "GAU",
         description="The set of convergence criteria to be used for the optimisation.",
     )

--- a/openff/qcsubmit/procedures.py
+++ b/openff/qcsubmit/procedures.py
@@ -2,7 +2,7 @@
 The procedure settings controllers
 """
 
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 from qcportal.optimization import OptimizationSpecification
 from typing_extensions import Literal
@@ -11,7 +11,6 @@ from openff.qcsubmit._pydantic import BaseModel, Field, validator
 from openff.qcsubmit.validators import (
     check_geometric_convergence,
     literal_lower,
-    literal_upper,
 )
 
 

--- a/openff/qcsubmit/procedures.py
+++ b/openff/qcsubmit/procedures.py
@@ -8,10 +8,7 @@ from qcportal.optimization import OptimizationSpecification
 from typing_extensions import Literal
 
 from openff.qcsubmit._pydantic import BaseModel, Field, validator
-from openff.qcsubmit.validators import (
-    check_geometric_convergence,
-    literal_lower,
-)
+from openff.qcsubmit.validators import check_geometric_convergence, literal_lower
 
 
 class GeometricProcedure(BaseModel):

--- a/openff/qcsubmit/procedures.py
+++ b/openff/qcsubmit/procedures.py
@@ -8,7 +8,11 @@ from qcportal.optimization import OptimizationSpecification
 from typing_extensions import Literal
 
 from openff.qcsubmit._pydantic import BaseModel, Field, validator
-from openff.qcsubmit.validators import literal_lower, literal_upper, check_geometric_convergence
+from openff.qcsubmit.validators import (
+    check_geometric_convergence,
+    literal_lower,
+    literal_upper,
+)
 
 
 class GeometricProcedure(BaseModel):
@@ -49,16 +53,16 @@ class GeometricProcedure(BaseModel):
 
            'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3'
 
-            Note that the units are Hartrees for energy and Bohr for distances. 
+            Note that the units are Hartrees for energy and Bohr for distances.
 
-            It is also possible to request that the optimization exit 
-            gracefully after hitting the maximum number of iterations by including 
+            It is also possible to request that the optimization exit
+            gracefully after hitting the maximum number of iterations by including
             an optional `maxiter` flag to the end of the string:
-            
+
             'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 maxiter'
 
             This can be used to run a few optimization steps to partially relax a molecule and eliminate high forces.
-            Nothing should follow the `maxiter` flag specified here in `convergence_set`. 
+            Nothing should follow the `maxiter` flag specified here in `convergence_set`.
             To specify the maximum number of iterations, please use the separate `maxiter` _keyword_.
     """
 

--- a/openff/qcsubmit/validators.py
+++ b/openff/qcsubmit/validators.py
@@ -38,6 +38,7 @@ def literal_upper(literal: str) -> str:
     """
     return literal.upper()
 
+
 def check_geometric_convergence(convergence_keywords: str) -> str:
     """
     Ensure GeomeTRIC convergence criteria are valid
@@ -45,45 +46,48 @@ def check_geometric_convergence(convergence_keywords: str) -> str:
     # If custom keywords are provided, check the format and values
     convergence_keyword_list = convergence_keywords.split()
     if len(convergence_keyword_list) > 1:
-        allowed_keys = ['energy','grms','gmax','drms','dmax','maxiter']
-        
+        allowed_keys = ["energy", "grms", "gmax", "drms", "dmax", "maxiter"]
+
         # Check if keywords are in allowed keys accepted by GeomeTRIC
-        for i,keyword in enumerate(convergence_keyword_list):
-            if i % 2 == 0: # Keywords with even index should be one of the allowed keys
+        for i, keyword in enumerate(convergence_keyword_list):
+            if i % 2 == 0:  # Keywords with even index should be one of the allowed keys
                 if keyword.lower() in allowed_keys:
                     # Make sure `maxiter` isn't followed by anything
-                    if keyword.lower() == 'maxiter':
+                    if keyword.lower() == "maxiter":
                         if i + 1 < len(convergence_keyword_list):
                             raise AssertionError(
                                 f"maxiter must be the last flag, and nothing should follow the maxiter flag specified here in convergence_set. To specify the maximum number of iterations, please use the separate maxiter keyword."
                             )
                     # Make sure corresponding entry can be converted to a float to be used as a convergence criterion
                     else:
-                        float(convergence_keyword_list[i+1]) 
+                        float(convergence_keyword_list[i + 1])
                 else:
                     raise AssertionError(
                         f"Provided convergence option not valid. Options accepted by GeomeTRIC: GAU, NWCHEM_LOOSE, GAU_LOOSE, TURBOMOLE, INTERFRAG_TIGHT, GAU_TIGHT, GAU_VERYTIGHT. Alternatively, provide a custom option using the format 'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 (optional: maxiter)'"
                     )
-            else: # Keywords with an odd index should be a float
+            else:  # Keywords with an odd index should be a float
                 float(keyword)
-        
+
         return convergence_keywords
-    
+
     # Otherwise ensure the one-word keyword is valid.
-    else: 
-        allowed_keys = ["GAU",
-                        "NWCHEM_LOOSE",
-                        "GAU_LOOSE",
-                        "TURBOMOLE",
-                        "INTERFRAG_TIGHT",
-                        "GAU_TIGHT",
-                        "GAU_VERYTIGHT"]
+    else:
+        allowed_keys = [
+            "GAU",
+            "NWCHEM_LOOSE",
+            "GAU_LOOSE",
+            "TURBOMOLE",
+            "INTERFRAG_TIGHT",
+            "GAU_TIGHT",
+            "GAU_VERYTIGHT",
+        ]
         if convergence_keywords.upper() not in allowed_keys:
             raise AssertionError(
                 f"Provided convergence option not valid. Options accepted by GeomeTRIC: GAU, NWCHEM_LOOSE, GAU_LOOSE, TURBOMOLE, INTERFRAG_TIGHT, GAU_TIGHT, GAU_VERYTIGHT. Alternatively, provide a custom option using the format 'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 (optional: maxiter)'"
             )
         else:
             return convergence_keywords.upper()
+
 
 def check_improper_connection(
     improper: Tuple[int, int, int, int], molecule: off.Molecule

--- a/openff/qcsubmit/validators.py
+++ b/openff/qcsubmit/validators.py
@@ -38,28 +38,52 @@ def literal_upper(literal: str) -> str:
     """
     return literal.upper()
 
-def check_geometric_convergence(convergence_keywords: Union[dict,str]) -> Union[dict,str]:
+def check_geometric_convergence(convergence_keywords: str) -> str:
     """
     Ensure GeomeTRIC convergence criteria are valid
     """
-    # If custom keywords are provided, check them
-    if type(convergence_keywords) == dict:
+    # If custom keywords are provided, check the format and values
+    convergence_keyword_list = convergence_keywords.split()
+    if len(convergence_keyword_list) > 1:
         allowed_keys = ['energy','grms','gmax','drms','dmax','maxiter']
         
-        # Check if key is in allowed keys accepted by GeomeTRIC
-        for key in convergence_keywords.keys():
-            if key.lower() in allowed_keys:
-                # Make sure key can be converted to a float to be used as a convergence criterion
-                if key.lower() != 'maxiter':
-                    float(convergence_keywords[key]) 
-            else:
-                raise AssertionError('Provided convergence option not valid. Options accepted by GeomeTRIC: energy, grms, gmax, drms, dmax, maxiter')
-                
+        # Check if keywords are in allowed keys accepted by GeomeTRIC
+        for i,keyword in enumerate(convergence_keyword_list):
+            if i % 2 == 0: # Keywords with even index should be one of the allowed keys
+                if keyword.lower() in allowed_keys:
+                    # Make sure `maxiter` isn't followed by anything
+                    if keyword.lower() == 'maxiter':
+                        if i + 1 < len(convergence_keyword_list):
+                            raise AssertionError(
+                                f"maxiter must be the last flag, and nothing should follow the maxiter flag specified here in convergence_set. To specify the maximum number of iterations, please use the separate maxiter keyword."
+                            )
+                    # Make sure corresponding entry can be converted to a float to be used as a convergence criterion
+                    else:
+                        float(convergence_keyword_list[i+1]) 
+                else:
+                    raise AssertionError(
+                        f"Provided convergence option not valid. Options accepted by GeomeTRIC: GAU, NWCHEM_LOOSE, GAU_LOOSE, TURBOMOLE, INTERFRAG_TIGHT, GAU_TIGHT, GAU_VERYTIGHT. Alternatively, provide a custom option using the format 'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 (optional: maxiter)'"
+                    )
+            else: # Keywords with an odd index should be a float
+                float(keyword)
+        
         return convergence_keywords
     
-    # Otherwise let the Literal validator handle it
+    # Otherwise ensure the one-word keyword is valid.
     else: 
-        return convergence_keywords.upper()
+        allowed_keys = ["GAU",
+                        "NWCHEM_LOOSE",
+                        "GAU_LOOSE",
+                        "TURBOMOLE",
+                        "INTERFRAG_TIGHT",
+                        "GAU_TIGHT",
+                        "GAU_VERYTIGHT"]
+        if convergence_keywords.upper() not in allowed_keys:
+            raise AssertionError(
+                f"Provided convergence option not valid. Options accepted by GeomeTRIC: GAU, NWCHEM_LOOSE, GAU_LOOSE, TURBOMOLE, INTERFRAG_TIGHT, GAU_TIGHT, GAU_VERYTIGHT. Alternatively, provide a custom option using the format 'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 (optional: maxiter)'"
+            )
+        else:
+            return convergence_keywords.upper()
 
 def check_improper_connection(
     improper: Tuple[int, int, int, int], molecule: off.Molecule

--- a/openff/qcsubmit/validators.py
+++ b/openff/qcsubmit/validators.py
@@ -56,14 +56,14 @@ def check_geometric_convergence(convergence_keywords: str) -> str:
                     if keyword.lower() == "maxiter":
                         if i + 1 < len(convergence_keyword_list):
                             raise AssertionError(
-                                f"maxiter must be the last flag, and nothing should follow the maxiter flag specified here in convergence_set. To specify the maximum number of iterations, please use the separate maxiter keyword."
+                                "maxiter must be the last flag, and nothing should follow the maxiter flag specified here in convergence_set. To specify the maximum number of iterations, please use the separate maxiter keyword."
                             )
                     # Make sure corresponding entry can be converted to a float to be used as a convergence criterion
                     else:
                         float(convergence_keyword_list[i + 1])
                 else:
                     raise AssertionError(
-                        f"Provided convergence option not valid. Options accepted by GeomeTRIC: GAU, NWCHEM_LOOSE, GAU_LOOSE, TURBOMOLE, INTERFRAG_TIGHT, GAU_TIGHT, GAU_VERYTIGHT. Alternatively, provide a custom option using the format 'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 (optional: maxiter)'"
+                        "Provided convergence option not valid. Options accepted by GeomeTRIC: GAU, NWCHEM_LOOSE, GAU_LOOSE, TURBOMOLE, INTERFRAG_TIGHT, GAU_TIGHT, GAU_VERYTIGHT. Alternatively, provide a custom option using the format 'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 (optional: maxiter)'"
                     )
             else:  # Keywords with an odd index should be a float
                 float(keyword)
@@ -83,7 +83,7 @@ def check_geometric_convergence(convergence_keywords: str) -> str:
         ]
         if convergence_keywords.upper() not in allowed_keys:
             raise AssertionError(
-                f"Provided convergence option not valid. Options accepted by GeomeTRIC: GAU, NWCHEM_LOOSE, GAU_LOOSE, TURBOMOLE, INTERFRAG_TIGHT, GAU_TIGHT, GAU_VERYTIGHT. Alternatively, provide a custom option using the format 'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 (optional: maxiter)'"
+                "Provided convergence option not valid. Options accepted by GeomeTRIC: GAU, NWCHEM_LOOSE, GAU_LOOSE, TURBOMOLE, INTERFRAG_TIGHT, GAU_TIGHT, GAU_VERYTIGHT. Alternatively, provide a custom option using the format 'energy 1e-6 grms 3e-4 gmax 4.5e-4 drms 1.2e-3 dmax 1.8e-3 (optional: maxiter)'"
             )
         else:
             return convergence_keywords.upper()

--- a/openff/qcsubmit/validators.py
+++ b/openff/qcsubmit/validators.py
@@ -38,6 +38,28 @@ def literal_upper(literal: str) -> str:
     """
     return literal.upper()
 
+def check_geometric_convergence(convergence_keywords: Union[dict,str]) -> Union[dict,str]:
+    """
+    Ensure GeomeTRIC convergence criteria are valid
+    """
+    # If custom keywords are provided, check them
+    if type(convergence_keywords) == dict:
+        allowed_keys = ['energy','grms','gmax','drms','dmax','maxiter']
+        
+        # Check if key is in allowed keys accepted by GeomeTRIC
+        for key in convergence_keywords.keys():
+            if key.lower() in allowed_keys:
+                # Make sure key can be converted to a float to be used as a convergence criterion
+                if key.lower() != 'maxiter':
+                    float(convergence_keywords[key]) 
+            else:
+                raise AssertionError('Provided convergence option not valid. Options accepted by GeomeTRIC: energy, grms, gmax, drms, dmax, maxiter')
+                
+        return convergence_keywords
+    
+    # Otherwise let the Literal validator handle it
+    else: 
+        return convergence_keywords.upper()
 
 def check_improper_connection(
     improper: Tuple[int, int, int, int], molecule: off.Molecule


### PR DESCRIPTION
## Description
Implementing custom convergence criteria in `GeometricProcedure`, to allow users to either specify their own convergence criteria, or use the `--converge maxiter` option to allow the program to exit gracefully on the maximum number of iterations. Implements #311  

I implemented this by changing the options for `convergence_set` from a `Literal` field that accepts only the hard-coded convergence criteria sets, to a `str` field that allows users to pass either an option from the hard-coded set, or a custom set that is in the format for GeomeTRIC and can just be passed directly to the program. I also added a new validator to parse the provided options and ensure they are valid and will be accepted by GeomeTRIC.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Implement custom convergence criteria other than the hard-coded GAU, TURBOMOLE, etc options
  - [ ] Implement support for the `--converge maxiter` option that allows the program to exit gracefully upon hitting the maximum number of iterations. It can only be used in conjunction with the custom convergence criteria, per GeomeTRIC's settings.
  - [ ] Test locally on QCFractal instance
  - [ ] Add CI tests to ensure that these new options run on QCArchive

## Questions
- [ ] Is the documentation clear enough? Unfortunately there is a lot of room for confusion with the `maxiter` option for `convergence_set` and the actual `maxiter` keyword, but that's how it's implemented in GeomeTRIC and I couldn't really think of an easy way around it that was less confusing. I tried to make it clear that they were different, but happy to take suggestions.

## Status
- [ ] Ready to go