### PR TITLE
Use Interchange 0.4.1 in CI until `openmmforcefields` is fixed

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -39,6 +39,7 @@ dependencies:
   # this should be changed to openff-toolkit-base
 
   - openff-toolkit
+  - openff-interchange-base <0.4.2  # 0.4.2 conflicts with openmmforcefields
   - openff-units ~=0.2.1
   - pydantic >1.10.17,<3
   - pyyaml

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -36,6 +36,7 @@ dependencies:
   ### Core dependencies.
 
   - openff-toolkit-base
+  - openff-interchange-base <0.4.2  # 0.4.2 conflicts with openmmforcefields
   - openff-units ~=0.2.1
   - rdkit
   - pydantic >1.10.17,<3


### PR DESCRIPTION
Band-aids #328 so I can see if other CI failures are new or not