### PR TITLE
Bump upstream(s) used in tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   test:
 
-    name: ${{ matrix.cfg.os }}, 🐍=${{ matrix.python-version }}, program=${{ matrix.cfg.conda-env }}, pydantic=${{ matrix.pydantic-version }}
+    name: ${{ matrix.cfg.os }}, 🐍=${{ matrix.python-version }}, program=${{ matrix.cfg.conda-env }}
     runs-on: ${{ matrix.cfg.os }}
 
     strategy:
@@ -26,13 +26,10 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-        pydantic-version:
-          - "2"
+          - "3.11"
+          - "3.12"
         cfg:
           - os: ubuntu-latest
-            conda-env: basic
-
-          - os: macOS-13
             conda-env: basic
 
           - os: macOS-latest
@@ -50,16 +47,14 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Conda Environment
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
 
         with:
           environment-file: devtools/conda-envs/${{ matrix.cfg.conda-env }}.yaml
           create-args: >-
             python=${{ matrix.python-version }}
-            pydantic=${{ matrix.pydantic-version }}
 
       - name: License OpenEye
-
         run: |
           echo "${SECRET_OE_LICENSE}" > ${OE_LICENSE}
           python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -41,7 +41,7 @@ dependencies:
   - openff-toolkit
   - openff-interchange-base <0.4.2  # 0.4.2 conflicts with openmmforcefields
   - openff-units ~=0.2.1
-  - pydantic >1.10.17,<3
+  - pydantic
   - pyyaml
   - torsiondrive
   - basis_set_exchange

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -39,7 +39,7 @@ dependencies:
   - openff-interchange-base <0.4.2  # 0.4.2 conflicts with openmmforcefields
   - openff-units ~=0.2.1
   - rdkit
-  - pydantic >1.10.17,<3
+  - pydantic
   - pyyaml
   - torsiondrive
   - basis_set_exchange


### PR DESCRIPTION
## Description
- [x] Bump Python versions to supported by ecosystem after April 4, 2025
- [x] Do not pass through Pydantic when only V2 is used
- [x] Do not test on Intel-based macOS

## Status
- [ ] Ready to go