### PR TITLE
Error when torsion drive is probably still running

### DIFF
--- a/openff/qcsubmit/exceptions.py
+++ b/openff/qcsubmit/exceptions.py
@@ -235,3 +235,9 @@ class ConflictingConvergeSettingsError(ValueError):
 
     error_type = "conflicting_converge_settings_error"
     header = "Conflicting Converge Settings Error"
+
+
+class RecordStillRunningError(QCSubmitException):
+
+    error_type = "record_still_running_error"
+    header = "Record Still Running Error"


### PR DESCRIPTION
## Description
Fixes https://github.com/openforcefield/openff-bespokefit/issues/393 by raising a more useful error message.

Arguably this could be a warning instead of an error, but there is potential for a significant behavior change if i.e. a fit is run on a partially-complete torsion drive dataset and re-run later when the compute is complete. This is not necessarily wholly bad, but an opinionated change we did not want to make here.

(Some extra comments in the code, and much more context in the linked issue.)

## Status
- [x] Ready to go