### PR TITLE
Improvements to record downloading and docstrings

### DIFF
--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -601,9 +601,7 @@ class OptimizationResultCollection(_BaseResultCollection):
 
             rec_ids = [result.record_id for result in results]
             # Do one big request to save time
-            opt_records = client.get_optimizations(
-                rec_ids, include=include
-            )
+            opt_records = client.get_optimizations(rec_ids, include=include)
             # Sort out which records from the request line up with which results
             opt_rec_id_to_result = dict()
             for result in results:


### PR DESCRIPTION
## Description
Prior to this PR, `optimization_result_collection.to_records()` downloads only the energies, first, and last molecules. It doesn't download the actual single point records, just the molecules. So the forces are not downloaded - they're later automatically downloaded when you hit the `record.topology property`. Today this manifested for me as the trivial line 

```py
assert record.topology is not None
```

taking 20 seconds - a great deal of time in a loop of a thousand elements, and extremely frustrating as I thought I had already downloaded this data. This PR makes improvements to the signatures and docstrings of the `collection.to_records()` and `OptimizationResultCollection.to_basic_result_collection()` methods that should enhance discoverability of this surprising behavior.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add `include` argument to `to_records()` to enable users to select which fields to download (and hint to user that not all fields are downloaded by default!)
  - [x] Revise docstrings for `to_records()` to better reflect their purpose
  - [x] Add a note to `OptimizationResultCollection.to_records()` docstring to explain that the user may want to call `.to_basic_result_collection()` first
  - [x] Revise docstring of `to_basic_result_collection()` with more details
  - [x] Add type annotation and default value to `to_basic_result_collection(driver)` argument

## Status
- [x] Ready to go