### PR TITLE
Improvements to record downloading and docstrings

### DIFF
--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -6,10 +6,10 @@ results from a QCFractal instance.
 from __future__ import annotations
 
 import abc
-from collections.abc import Sequence
 import logging
 import warnings
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -397,7 +397,9 @@ class BasicResultCollection(_BaseResultCollection):
             spec_name,
         )
 
-    def to_records(self, include: Iterable[str] = ("Molecule",)) -> List[Tuple[SinglepointRecord, Molecule]]:
+    def to_records(
+        self, include: Iterable[str] = ("Molecule",)
+    ) -> List[Tuple[SinglepointRecord, Molecule]]:
         """Download all records referenced in this collection from QCFractal.
 
         Returns the native QCPortal record objects for each of the records
@@ -628,7 +630,9 @@ class OptimizationResultCollection(_BaseResultCollection):
 
         return records_and_molecules
 
-    def to_basic_result_collection(self, driver: Iterable[SinglepointDriver] | None = None) -> BasicResultCollection:
+    def to_basic_result_collection(
+        self, driver: Iterable[SinglepointDriver] | None = None
+    ) -> BasicResultCollection:
         """
         Get a collection of the single point results from the end of each optimization.
 

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -398,7 +398,7 @@ class BasicResultCollection(_BaseResultCollection):
         )
 
     def to_records(
-        self, include: Iterable[str] = ("Molecule",)
+        self, include: Iterable[str] = ("molecule",)
     ) -> List[Tuple[SinglepointRecord, Molecule]]:
         """Download all records referenced in this collection from QCFractal.
 
@@ -411,11 +411,15 @@ class BasicResultCollection(_BaseResultCollection):
         Parameters
         ==========
         include
-            The fields to download when the record is collected.
+            The fields to download when the record is collected. The
+            ``"molecule"`` field is always downloaded.
         """
         from openff.qcsubmit.utils.utils import _default_portal_client
 
         records_and_molecules = []
+
+        if "molecule" not in include:
+            include = ("molecule", *include)
 
         for client_address, records in self.entries.items():
             client = _default_portal_client(client_address)
@@ -575,7 +579,8 @@ class OptimizationResultCollection(_BaseResultCollection):
         Parameters
         ==========
         include
-            The fields to download when the record is collected.
+            The fields to download when the record is collected. The
+            ``"final_molecule"`` field is always downloaded.
 
         Notes
         =====
@@ -588,13 +593,16 @@ class OptimizationResultCollection(_BaseResultCollection):
 
         records_and_molecules = []
 
+        if "final_molecule" not in include:
+            include = ("final_molecule", *include)
+
         for client_address, results in self.entries.items():
             client = _default_portal_client(client_address)
 
             rec_ids = [result.record_id for result in results]
             # Do one big request to save time
             opt_records = client.get_optimizations(
-                rec_ids, include=["initial_molecule", "final_molecule"]
+                rec_ids, include=include
             )
             # Sort out which records from the request line up with which results
             opt_rec_id_to_result = dict()
@@ -880,11 +888,15 @@ class TorsionDriveResultCollection(_BaseResultCollection):
         Parameters
         ==========
         include
-            The fields to download when the record is collected.
+            The fields to download when the record is collected. The
+            ``"minimum_optimizations"`` field is always downloaded.
         """
         from openff.qcsubmit.utils.utils import _default_portal_client
 
         records_and_molecules = []
+
+        if "minimum_optimizations" not in include:
+            include = ("minimum_optimizations", *include)
 
         for client_address, records in self.entries.items():
             client = _default_portal_client(client_address)
@@ -893,7 +905,7 @@ class TorsionDriveResultCollection(_BaseResultCollection):
             # minimum_optimizations
             record_ids = [r.record_id for r in records]
             torsion_drive_records = client.get_torsiondrives(
-                record_ids, include=["minimum_optimizations"]
+                record_ids, include=include
             )
             for record, rec in zip(records, torsion_drive_records):
                 # OpenFF molecule

--- a/openff/qcsubmit/results/results.py
+++ b/openff/qcsubmit/results/results.py
@@ -601,9 +601,7 @@ class OptimizationResultCollection(_BaseResultCollection):
 
             rec_ids = [result.record_id for result in results]
             # Do one big request to save time
-            opt_records = client.get_optimizations(
-                rec_ids, include=include
-            )
+            opt_records = client.get_optimizations(rec_ids, include=include)
             # Sort out which records from the request line up with which results
             opt_rec_id_to_result = dict()
             for result in results:


### PR DESCRIPTION
## Description
Prior to this PR, `optimization_result_collection.to_records()` downloads only the energies, first, and last molecules. It doesn't download the actual single point records, just the molecules. So the forces are not downloaded - they're later automatically downloaded when you hit the `record.topology property`. Today this manifested for me as the trivial line 

```py
assert record.topology is not None
```

taking 20 seconds - a great deal of time in a loop of a thousand elements, and extremely frustrating as I thought I had already downloaded this data. This PR makes improvements to the signatures and docstrings of the `collection.to_records()` and `OptimizationResultCollection.to_basic_result_collection()` methods that should enhance discoverability of this surprising behavior.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add `include` argument to `to_records()` to enable users to select which fields to download (and hint to user that not all fields are downloaded by default!)
  - [x] Revise docstrings for `to_records()` to better reflect their purpose
  - [x] Add a note to `OptimizationResultCollection.to_records()` docstring to explain that the user may want to call `.to_basic_result_collection()` first
  - [x] Revise docstring of `to_basic_result_collection()` with more details
  - [x] Add type annotation and default value to `to_basic_result_collection(driver)` argument

## Status
- [x] Ready to go