### PR TITLE
Revert "Avoid NumPy 2.4"

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -12,9 +12,6 @@ dependencies:
   - pip
   - setuptools
 
-  # Temporary
-  - numpy <2.4
-
   # Testing
   - pytest
   - pytest-cov

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -12,9 +12,6 @@ dependencies:
   - pip
   - setuptools
 
-  # Temporary
-  - numpy <2.4
-
   # Testing
   - pytest
   - pytest-cov


### PR DESCRIPTION
Reverts openforcefield/openff-qcsubmit#364

This is no longer needed with Interchange 0.4.11+