### PR TITLE
Disable bleeding edge tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
           - "3.13"
         bleeding-edge:
           - true
-          - false
+          #- false
         cfg:
           - os: ubuntu-latest
             conda-env: basic

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,8 +29,8 @@ jobs:
           - "3.12"
           - "3.13"
         bleeding-edge:
-          - true
-          #- false
+          #- true
+          - false
         cfg:
           - os: ubuntu-latest
             conda-env: basic


### PR DESCRIPTION
## Description
I know that bleeding edge tests fail and have a ticket in the backlog to update things. We can spare the CI runners and my inbox some futile work by disabling these tests.
