### PR TITLE
Update for OpenMMForceFields 0.16, refactor validation and add tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,8 +37,8 @@ jobs:
           - os: macOS-latest
             conda-env: basic
 
-          #- os: ubuntu-latest
-          #  conda-env: psi4
+          - os: ubuntu-latest
+            conda-env: psi4
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,6 +53,7 @@ jobs:
           environment-file: devtools/conda-envs/${{ matrix.cfg.conda-env }}.yaml
           create-args: >-
             python=${{ matrix.python-version }}
+          micromamba-version: '2.8.1'
 
       - name: License OpenEye
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
           environment-file: devtools/conda-envs/${{ matrix.cfg.conda-env }}.yaml
           create-args: >-
             python=${{ matrix.python-version }}
-          micromamba-version: '2.8.1'
+          micromamba-version: 2.8.1
 
       - name: License OpenEye
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,8 +37,8 @@ jobs:
           - os: macOS-latest
             conda-env: basic
 
-          - os: ubuntu-latest
-            conda-env: psi4
+          #- os: ubuntu-latest
+          #  conda-env: psi4
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
           environment-file: devtools/conda-envs/${{ matrix.cfg.conda-env }}.yaml
           create-args: >-
             python=${{ matrix.python-version }}
-          micromamba-version: 2.8.1
+          micromamba-version: 2.8.1-0
 
       - name: License OpenEye
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,6 @@ jobs:
           environment-file: devtools/conda-envs/${{ matrix.cfg.conda-env }}.yaml
           create-args: >-
             python=${{ matrix.python-version }}
-          micromamba-version: 2.8.1-0
 
       - name: License OpenEye
         run: |

--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -49,6 +49,6 @@ dependencies:
   - h5py>=3.6.0
 
   # Optional
-  - openmmforcefields ~=0.14.2
+  - openmmforcefields >=0.15.0
   - openff-fragmenter-base >=0.2.0
   - mdtraj

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -46,7 +46,7 @@ dependencies:
   - h5py>=3.6.0
 
   # Optional
-  - openmmforcefields ~=0.14.2
+  - openmmforcefields >=0.15.0
   - openff-fragmenter-base >=0.2.0
   - openmm
   - mdtraj

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -31,9 +31,6 @@ dependencies:
 
   - psi4 >=1.9.1
   - pyddx
-  # Current best reference for this pin (please update if a more visible issue is opened)
-  # https://github.com/psi4/psi4/pull/3464#issuecomment-5189313038
-  - libxc-c =7.0.0
 
   ### Core dependencies.
 

--- a/devtools/conda-envs/psi4.yaml
+++ b/devtools/conda-envs/psi4.yaml
@@ -31,6 +31,9 @@ dependencies:
 
   - psi4 >=1.9.1
   - pyddx
+  # Current best reference for this pin (please update if a more visible issue is opened)
+  # https://github.com/psi4/psi4/pull/3464#issuecomment-5189313038
+  - libxc-c =7.0.0
 
   ### Core dependencies.
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -13,7 +13,33 @@ Releases are given with dates in DD-MM-YYYY format.
 
 ### API/Behavior Changes
 
-* [PR #394:] Updates for openmmforcefields 0.16. When using the `openmm` program, QCSubmit passes `method` names as if they were small molecule force fields. The interpretation of this field has changed in OMMFFs 0.16 so strings like `openff_unconstrained-1.1.0` now need to be written as full OFFXML names like `openff_unconstrained-1.1.0.offxml`. This behavior change passes through to QCSubmit's `method` field. See https://github.com/openmm/openmmforcefields/releases/tag/0.16.0 for details.
+[PR #394:] Updates for openmmforcefields 0.16. When using the `openmm` program and `smirnoff` basis, 
+QCSubmit passes `method` names to QCEngine, which passes them to openmm/openmmforcefields as if they 
+were small molecule force fields.
+* This PR removes some sanitization of force field names. Earlier versions of QCSubmit used to lowercase 
+  and strip the `.offxml` suffix from force fields before sending them to QCEngine (and thereby openmmforcefields).
+  This is no longer the case, QCSubmit now passes SMIRNOFF `method` names to QCEngine unchanged. 
+* The interpretation/application of SMIRNOFF force fields has changed in openmmforcefields 0.16. 
+  Notably, **openmmforcefields used to unconditionally strip `<Constraints>` from SMIRNOFF force fields and then 
+  re-apply constraints based on a separate argument (the `constraints` kwarg)**. As of openmmforcefields
+  0.16, the `<Constraints>` section is no longer stripped, and the final set of constraints applied is the UNION
+  of those requested by the SMIRNOFF force field and those requested by the `constraints` kwarg passed to 
+  openmmforcefields.
+
+This table shows the behavior of QCSubmit+QCEngine+OpenMMForceFields before and after these changes:
+
+|                                   | OpenMMForceFields <0.16 and QCSubmit <=0.57.0                                | OpenMMForceFields >=0.16 and QCSubmit >0.57.0                              |
+|-----------------------------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------|
+| openff-X.Y.Z                      | Applies openff-X.Y.Z.offxml with <Constraints> section deleted               | Applies openff_unconstrained-X.Y.Z.offxml per SMIRNOFF spec (minor change) |
+| openff-X.Y.Z.offxml               | QCSubmit deletes `.offxml` suffix so behavior is identical to row above      | Applies openff-X.Y.Z.offxml per SMIRNOFF spec (MAJOR change)               |
+| openff_unconstrained-X.Y.Z        | Applies openff_unconstrained-X.Y.Z.offxml with <Constraints> section deleted | Raises an error                                                            |
+| openff_unconstrained-X.Y.Z.offxml | QCSubmit deletes `.offxml` suffix so behavior is identical to row above      | Applies openff_unconstrained-X.Y.Z.offxml per SMIRNOFF spec (minor change) |
+
+To the best of Jeff's knowledge, OpenFF [has not submitted](https://github.com/search?q=repo%3Aopenforcefield%2Fqca-dataset-submission+%22method%22%3A+%22openff+path%3A*json&type=code) 
+any datasets to QCArchive that A) would encounter the "MAJOR change" case above or B) use the now-forbidden 
+`openff_unconstrained-X.Y.Z` string, so all QC datasets should still be readable and computations reproducible (modulo
+water constraints). See https://github.com/openmm/openmmforcefields/releases/tag/0.16.0 for details on the 
+openmmforcefields release.
 
 ### Testing/packaging updates
 
@@ -215,6 +241,7 @@ For more information on this release, see https://github.com/openforcefield/open
 [PR #381:]: https://github.com/openforcefield/openff-qcsubmit/pull/381
 [PR #382:]: https://github.com/openforcefield/openff-qcsubmit/pull/382
 [PR #387:]: https://github.com/openforcefield/openff-qcsubmit/pull/387
+[PR #394:]: https://github.com/openforcefield/openff-qcsubmit/pull/394
 
 [@jthorton]: https://github.com/jthorton
 [@dotsdl]: https://github.com/dotsdl

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,7 +11,11 @@ Releases are given with dates in DD-MM-YYYY format.
 
 <!--## Version / Date DD-MM-YYYY -->
 
-## Current development
+### API/Behavior Changes
+
+* [PR #394:] Updates for openmmforcefields 0.16. When using the `openmm` program, QCSubmit passes `method` names as if they were small molecule force fields. The interpretation of this field has changed in OMMFFs 0.16 so strings like `openff_unconstrained-1.1.0` now need to be written as full OFFXML names like `openff_unconstrained-1.1.0.offxml`. This behavior change passes through to QCSubmit's `method` field. See https://github.com/openmm/openmmforcefields/releases/tag/0.16.0 for details.
+
+### Testing/packaging updates
 
 * [PR #381:] Switches version handling to use `setuptools-scm`.
 * [PR #367:] Do not use `pkg_resources`

--- a/openff/qcsubmit/_tests/test_common_structures.py
+++ b/openff/qcsubmit/_tests/test_common_structures.py
@@ -8,18 +8,23 @@ from openff.qcsubmit.common_structures import Metadata, MoleculeAttributes, QCSp
 from openff.qcsubmit.exceptions import DatasetInputError, QCSpecificationError
 
 
-def _block_import(*module_prefixes):
+def _block_import(*module_prefixes, error=ModuleNotFoundError):
     """
-    Return a stand-in for `builtins.__import__` that raises ModuleNotFoundError
-    for any import whose name starts with one of the given prefixes, and
-    otherwise behaves normally. Used to simulate an optional dependency (e.g.
-    openmmforcefields) not being installed.
+    Return a stand-in for `builtins.__import__` that raises `error` for any
+    import whose name starts with one of the given prefixes, and otherwise
+    behaves normally.
+
+    The default (`ModuleNotFoundError`) simulates an optional dependency
+    (e.g. openmmforcefields) not being installed. Passing
+    `error=AssertionError` instead proves that an import is never *attempted*
+    at all, rather than merely that a resulting ModuleNotFoundError doesn't
+    propagate.
     """
     real_import = builtins.__import__
 
     def blocked_import(name, *args, **kwargs):
         if any(name.startswith(prefix) for prefix in module_prefixes):
-            raise ModuleNotFoundError(f"No module named {name!r} (blocked for testing)")
+            raise error(f"Import of {name!r} blocked for testing")
         return real_import(name, *args, **kwargs)
 
     return blocked_import
@@ -157,29 +162,35 @@ def test_openmm_method_preserves_offxml_extension(method):
     Regression test: QCSpec used to unconditionally strip a trailing ".offxml"
     off of `method` before storing it. This silently turned a request for the
     *constrained* force field variant (e.g. "openff-1.0.0.offxml") into the
-    bare shorthand "openff-1.0.0", which openmmforcefields resolves to the
-    *unconstrained* variant instead - a silent, wrong-physics bug rather than
-    an error. The user-provided spelling (up to lowercasing) must survive
-    unchanged.
+    bare shorthand "openff-1.0.0", which openmmforcefields >=0.16 treats
+    differently than <0.16. The user-provided spelling must survive unchanged. This
+    requires openmmforcefields to be installed, since validation (and thus
+    any normalization of `method`) is skipped entirely without it.
     """
+    pytest.importorskip("openmmforcefields")
     spec = QCSpec(method=method, basis="smirnoff", program="openmm")
-    assert spec.method == method.lower()
+    assert spec.method == method
 
 
 def test_bare_unconstrained_method_rejected():
     """
+    Starting in openmmforcefields 0.16.0,
     "openff_unconstrained-X.Y.Z" (no .offxml extension) is not a name that
     openmmforcefields' SMIRNOFFTemplateGenerator recognizes: it isn't in the
     curated shorthand list (bare "openff-X.Y.Z" names, which already resolve
     to the unconstrained variant) and it isn't a valid filename on its own.
     This should be rejected here, rather than passing validation and later
-    failing deep inside SystemGenerator with a confusing error.
+    failing deep inside SystemGenerator with a confusing error. This requires
+    openmmforcefields to be installed, since validation is skipped entirely
+    without it (see test_openmm_validation_skipped_without_openmmforcefields).
     """
+    pytest.importorskip("openmmforcefields")
     with pytest.raises(QCSpecificationError):
         QCSpec(method="openff_unconstrained-1.0.0", basis="smirnoff", program="openmm")
 
 
 def test_gaff_method_is_accepted():
+    pytest.importorskip("openmmforcefields")
     spec = QCSpec(method="gaff-2.2.20", basis="antechamber", program="openmm")
     assert spec.method == "gaff-2.2.20"
 
@@ -192,6 +203,25 @@ def test_gaff_method_is_accepted():
             "The Basis not-a-real-basis is not supported",
         ),
         (
+            dict(method="uff", basis="not-none", program="rdkit"),
+            r"choose from \(None,\)",
+        ),
+    ],
+)
+def test_qcspec_invalid_combinations_raise(kwargs, match):
+    """
+    Test of basis/program pemutations that don't require openmmforcefields to be installed for validation.
+    Note that erroring on an invalid openmm BASIS can be done without the openmmforcefields package, but
+    checking the METHOD for a valid basis will attempt to use openmmforcefields (see tests below)
+    """
+    with pytest.raises(QCSpecificationError, match=match):
+        QCSpec(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        (
             dict(method="not-a-real-forcefield", basis="smirnoff", program="openmm"),
             "The method not-a-real-forcefield is not supported",
         ),
@@ -203,13 +233,16 @@ def test_gaff_method_is_accepted():
             ),
             "The method not-a-real-gaff-version is not supported",
         ),
-        (
-            dict(method="uff", basis="not-none", program="rdkit"),
-            r"choose from \(None,\)",
-        ),
     ],
 )
-def test_qcspec_invalid_combinations_raise(kwargs, match):
+def test_qcspec_invalid_openmm_method_raises(kwargs, match):
+    """
+    These cases are only rejected once `method` is checked against the
+    force fields openmmforcefields knows about, so they require it to be
+    installed (see test_openmm_validation_skipped_without_openmmforcefields
+    for what happens to invalid methods when it isn't).
+    """
+    pytest.importorskip("openmmforcefields")
     with pytest.raises(QCSpecificationError, match=match):
         QCSpec(**kwargs)
 
@@ -252,9 +285,13 @@ def test_default_qcspec_does_not_require_openmmforcefields(monkeypatch):
     The default (psi4) QCSpec, and any other non-"openmm" program, must never
     even attempt to import openmmforcefields: it's an optional dependency, and
     the overwhelming majority of QCSpecs - including the bare `QCSpec()` used
-    when retrieving/exporting datasets - have nothing to do with OpenMM.
+    when retrieving/exporting datasets - have nothing to do with OpenMM. Using
+    `error=AssertionError` here proves the import is never attempted, not
+    merely that a resulting ModuleNotFoundError doesn't propagate.
     """
-    monkeypatch.setattr(builtins, "__import__", _block_import("openmmforcefields"))
+    monkeypatch.setattr(
+        builtins, "__import__", _block_import("openmmforcefields", error=AssertionError)
+    )
 
     QCSpec()  # should not raise
 
@@ -266,8 +303,11 @@ def test_unrelated_module_not_found_error_is_not_masked(monkeypatch):
     unrelated ModuleNotFoundError raised later while building the
     allowed-methods list (e.g. from a broken third-party offxml plugin during
     force field discovery). Such a failure must propagate normally, not be
-    silently reinterpreted as "openmmforcefields is not installed".
+    silently reinterpreted as "openmmforcefields is not installed". Requires
+    openmmforcefields to actually be installed, since this test is exercising
+    what happens *after* that import succeeds.
     """
+    pytest.importorskip("openmmforcefields")
     import openff.toolkit.typing.engines.smirnoff as smirnoff_mod
 
     def broken_get_available_force_fields():

--- a/openff/qcsubmit/_tests/test_common_structures.py
+++ b/openff/qcsubmit/_tests/test_common_structures.py
@@ -192,9 +192,7 @@ def test_gaff_method_is_accepted():
             "The Basis not-a-real-basis is not supported",
         ),
         (
-            dict(
-                method="not-a-real-forcefield", basis="smirnoff", program="openmm"
-            ),
+            dict(method="not-a-real-forcefield", basis="smirnoff", program="openmm"),
             "The method not-a-real-forcefield is not supported",
         ),
         (

--- a/openff/qcsubmit/_tests/test_common_structures.py
+++ b/openff/qcsubmit/_tests/test_common_structures.py
@@ -172,6 +172,24 @@ def test_openmm_method_preserves_offxml_extension(method):
     assert spec.method == method
 
 
+def test_openmm_method_is_case_sensitive():
+    """
+    Regression test: force field names are case-sensitive filenames, unlike
+    `program`/`basis`, so QCSpec must not lowercase `method` before comparing
+    it against the installed force fields. The real installed file is
+    "openff-1.0.0-RC1.offxml" (uppercase RC); the otherwise-identical
+    lowercase spelling isn't a real file and must be rejected rather than
+    silently accepted via case-insensitive matching.
+    """
+    pytest.importorskip("openmmforcefields")
+
+    spec = QCSpec(method="openff-1.0.0-RC1.offxml", basis="smirnoff", program="openmm")
+    assert spec.method == "openff-1.0.0-RC1.offxml"
+
+    with pytest.raises(QCSpecificationError):
+        QCSpec(method="openff-1.0.0-rc1.offxml", basis="smirnoff", program="openmm")
+
+
 def test_bare_unconstrained_method_rejected():
     """
     Starting in openmmforcefields 0.16.0,

--- a/openff/qcsubmit/_tests/test_common_structures.py
+++ b/openff/qcsubmit/_tests/test_common_structures.py
@@ -1,9 +1,28 @@
+import builtins
+
 import pytest
 from openff.toolkit.topology import Molecule
 
 from openff.qcsubmit._tests import does_not_raise
 from openff.qcsubmit.common_structures import Metadata, MoleculeAttributes, QCSpec
 from openff.qcsubmit.exceptions import DatasetInputError, QCSpecificationError
+
+
+def _block_import(*module_prefixes):
+    """
+    Return a stand-in for `builtins.__import__` that raises ModuleNotFoundError
+    for any import whose name starts with one of the given prefixes, and
+    otherwise behaves normally. Used to simulate an optional dependency (e.g.
+    openmmforcefields) not being installed.
+    """
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if any(name.startswith(prefix) for prefix in module_prefixes):
+            raise ModuleNotFoundError(f"No module named {name!r} (blocked for testing)")
+        return real_import(name, *args, **kwargs)
+
+    return blocked_import
 
 
 def test_attributes_from_openff_molecule():
@@ -123,3 +142,142 @@ def test_scf_prop_validation():
 
     with pytest.raises(QCSpecificationError):
         QCSpec(scf_properties=["ddec_charges"])
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "openff_unconstrained-1.0.0.offxml",
+        "openff-1.0.0.offxml",
+        "openff-1.0.0",
+    ],
+)
+def test_openmm_method_preserves_offxml_extension(method):
+    """
+    Regression test: QCSpec used to unconditionally strip a trailing ".offxml"
+    off of `method` before storing it. This silently turned a request for the
+    *constrained* force field variant (e.g. "openff-1.0.0.offxml") into the
+    bare shorthand "openff-1.0.0", which openmmforcefields resolves to the
+    *unconstrained* variant instead - a silent, wrong-physics bug rather than
+    an error. The user-provided spelling (up to lowercasing) must survive
+    unchanged.
+    """
+    spec = QCSpec(method=method, basis="smirnoff", program="openmm")
+    assert spec.method == method.lower()
+
+
+def test_bare_unconstrained_method_rejected():
+    """
+    "openff_unconstrained-X.Y.Z" (no .offxml extension) is not a name that
+    openmmforcefields' SMIRNOFFTemplateGenerator recognizes: it isn't in the
+    curated shorthand list (bare "openff-X.Y.Z" names, which already resolve
+    to the unconstrained variant) and it isn't a valid filename on its own.
+    This should be rejected here, rather than passing validation and later
+    failing deep inside SystemGenerator with a confusing error.
+    """
+    with pytest.raises(QCSpecificationError):
+        QCSpec(method="openff_unconstrained-1.0.0", basis="smirnoff", program="openmm")
+
+
+def test_gaff_method_is_accepted():
+    spec = QCSpec(method="gaff-2.2.20", basis="antechamber", program="openmm")
+    assert spec.method == "gaff-2.2.20"
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        (
+            dict(method="openff-2.3.0", basis="not-a-real-basis", program="openmm"),
+            "The Basis not-a-real-basis is not supported",
+        ),
+        (
+            dict(
+                method="not-a-real-forcefield", basis="smirnoff", program="openmm"
+            ),
+            "The method not-a-real-forcefield is not supported",
+        ),
+        (
+            dict(
+                method="not-a-real-gaff-version",
+                basis="antechamber",
+                program="openmm",
+            ),
+            "The method not-a-real-gaff-version is not supported",
+        ),
+        (
+            dict(method="uff", basis="not-none", program="rdkit"),
+            r"choose from \(None,\)",
+        ),
+    ],
+)
+def test_qcspec_invalid_combinations_raise(kwargs, match):
+    with pytest.raises(QCSpecificationError, match=match):
+        QCSpec(**kwargs)
+
+
+def test_openmm_validation_skipped_without_openmmforcefields(monkeypatch):
+    """
+    openmmforcefields is an optional dependency. If it isn't installed, QCSpec
+    construction must still succeed - just with method-name validation
+    skipped and a warning raised - rather than a hard failure.
+    """
+    monkeypatch.setattr(builtins, "__import__", _block_import("openmmforcefields"))
+
+    with pytest.warns(UserWarning, match="openmmforcefields is not installed"):
+        spec = QCSpec(method="openff-2.3.0", basis="smirnoff", program="openmm")
+
+    assert spec.method == "openff-2.3.0"
+
+
+def test_openmm_spec_deserialization_without_openmmforcefields(monkeypatch):
+    """
+    QCSpec validation runs on every pydantic deserialization of a stored
+    dataset (it's a pydantic field type, not just a constructor called at
+    submission time), not just at first construction. Loading a
+    previously-created OpenMM/SMIRNOFF dataset spec must not require
+    openmmforcefields to be installed, or simply inspecting/retrieving an old
+    dataset becomes impossible on a lightweight (openff-toolkit-only) install.
+    """
+    monkeypatch.setattr(builtins, "__import__", _block_import("openmmforcefields"))
+
+    with pytest.warns(UserWarning, match="openmmforcefields is not installed"):
+        spec = QCSpec.parse_obj(
+            {"method": "openff-2.3.0", "basis": "smirnoff", "program": "openmm"}
+        )
+
+    assert spec.method == "openff-2.3.0"
+
+
+def test_default_qcspec_does_not_require_openmmforcefields(monkeypatch):
+    """
+    The default (psi4) QCSpec, and any other non-"openmm" program, must never
+    even attempt to import openmmforcefields: it's an optional dependency, and
+    the overwhelming majority of QCSpecs - including the bare `QCSpec()` used
+    when retrieving/exporting datasets - have nothing to do with OpenMM.
+    """
+    monkeypatch.setattr(builtins, "__import__", _block_import("openmmforcefields"))
+
+    QCSpec()  # should not raise
+
+
+def test_unrelated_module_not_found_error_is_not_masked(monkeypatch):
+    """
+    Regression test: the ModuleNotFoundError guard around the
+    openmmforcefields import must not be so wide that it also swallows an
+    unrelated ModuleNotFoundError raised later while building the
+    allowed-methods list (e.g. from a broken third-party offxml plugin during
+    force field discovery). Such a failure must propagate normally, not be
+    silently reinterpreted as "openmmforcefields is not installed".
+    """
+    import openff.toolkit.typing.engines.smirnoff as smirnoff_mod
+
+    def broken_get_available_force_fields():
+        raise ModuleNotFoundError("No module named 'some_unrelated_broken_plugin'")
+
+    monkeypatch.setattr(
+        smirnoff_mod, "get_available_force_fields", broken_get_available_force_fields
+    )
+
+    with pytest.raises(ModuleNotFoundError, match="some_unrelated_broken_plugin"):
+        QCSpec(method="openff-2.3.0.offxml", basis="smirnoff", program="openmm")

--- a/openff/qcsubmit/_tests/test_submissions.py
+++ b/openff/qcsubmit/_tests/test_submissions.py
@@ -736,7 +736,7 @@ def test_optimization_submissions_with_constraints(fulltest_client):
         pytest.param(
             (
                 {
-                    "method": "openff_unconstrained-1.0.0",
+                    "method": "openff_unconstrained-1.0.0.offxml",
                     "basis": "smirnoff",
                     "program": "openmm",
                 },
@@ -1145,7 +1145,7 @@ def test_torsiondrive_scan_keywords(fulltest_client):
     factory.add_workflow_components(scan_enum)
     factory.clear_qcspecs()
     factory.add_qc_spec(
-        method="openff_unconstrained-1.1.0",
+        method="openff_unconstrained-1.1.0.offxml",
         basis="smirnoff",
         program="openmm",
         spec_description="scan range test",
@@ -1257,7 +1257,7 @@ def test_torsiondrive_constraints(fulltest_client):
         pytest.param(
             (
                 {
-                    "method": "openff_unconstrained-1.1.0",
+                    "method": "openff_unconstrained-1.1.0.offxml",
                     "basis": "smirnoff",
                     "program": "openmm",
                 },

--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -6,6 +6,7 @@ import abc
 import copy
 import getpass
 import re
+import warnings
 from datetime import date, datetime
 from enum import Enum
 from typing import (
@@ -514,35 +515,11 @@ class QCSpec(ResultsConfig):
         """
         Validate the combination of method, basis and program.
         """
-        from openff.toolkit.typing.engines.smirnoff import get_available_force_fields
-
-        try:
-            from openmmforcefields.generators.template_generators import (
-                GAFFTemplateGenerator,
-            )
-
-            gaff_forcefields = GAFFTemplateGenerator.INSTALLED_FORCEFIELDS
-
-        except ModuleNotFoundError:
-            gaff_forcefields = [
-                "gaff-1.4",
-                "gaff-1.8",
-                "gaff-1.81",
-                "gaff-2.1",
-                "gaff-2.11",
-            ]
-
-        # set up the valid method basis and program combinations
+        # Set up the valid method basis and program combinations.
+        # We validate program=openmm later because we get its supported
+        # methods/bases from a live API point, but it's an optional dep
+        # so we import-guard it.
         ani_methods = {"ani1x", "ani1ccx", "ani2x"}
-        openff_forcefields = list(
-            ff.split(".offxml")[0].lower() for ff in get_available_force_fields()
-        )
-
-        openmm_forcefields = {
-            "smirnoff": openff_forcefields,
-            "antechamber": gaff_forcefields,
-        }
-
         xtb_methods = {
             "gfn0-xtb",
             "gfn0xtb",
@@ -554,37 +531,78 @@ class QCSpec(ResultsConfig):
             "gfnff",
         }
         rdkit_methods = {"uff", "mmff94", "mmff94s"}
-        settings = {
-            "openmm": openmm_forcefields,
-            "torchani": {None: ani_methods},
-            "xtb": {None: xtb_methods},
-            "rdkit": {None: rdkit_methods},
-        }
+        known_programs = {"openmm", "torchani", "xtb", "rdkit"}
 
-        if program.lower() in settings:
+        if program.lower() in known_programs:
             # make sure PCM is not set
             if implicit_solvent is not None:
                 raise QCSpecificationError(
-                    "PCM and DDX can only be used with PSI4 please set implicit solvent to None."
+                    "PCM and DDX can only be used with PSI4. Please set implicit solvent to None."
                 )
-            # we need to make sure it is valid in the above list
-            program_settings = settings.get(program.lower(), None)
-            if program_settings is None:
-                raise QCSpecificationError(
-                    f"The program {program.lower()} is not supported please use one of the following {settings.keys()}"
-                )
-            allowed_methods = program_settings.get(basis, None)
-            if allowed_methods is None:
-                raise QCSpecificationError(
-                    f"The Basis {basis} is not supported for the program {program}, chose from {program_settings.keys()}"
-                )
-            # now we need to check the methods
-            # strip the offxml if present
-            method = method.split(".offxml")[0].lower()
-            if method not in allowed_methods:
-                raise QCSpecificationError(
-                    f"The method {method} is not supported for the program {program} with basis {basis}, please chose from {allowed_methods}"
-                )
+
+            if program.lower() == "openmm":
+                known_openmm_bases = ("smirnoff", "antechamber")
+                if basis not in known_openmm_bases:
+                    raise QCSpecificationError(
+                        f"The Basis {basis} is not supported for the program {program}, choose "
+                        f"from {known_openmm_bases}"
+                    )
+
+                try:
+                    from openmmforcefields.generators.template_generators import (
+                        GAFFTemplateGenerator,
+                        SMIRNOFFTemplateGenerator,
+                    )
+                    ommffs_installed = True
+                except ModuleNotFoundError:
+                    ommffs_installed = False
+
+                method = method.lower()
+                if not ommffs_installed:
+                    warnings.warn(
+                        "openmmforcefields is not installed, so the requested OpenMM "
+                        f"method {method!r} (basis={basis!r}) could not be validated. "
+                        "Install openmmforcefields (e.g. `conda install -c conda-forge "
+                        "openmmforcefields`) to enable this check.",
+                        stacklevel=2,
+                    )
+                else:
+                    from openff.toolkit.typing.engines.smirnoff import (
+                        get_available_force_fields,
+                    )
+
+                    allowed_methods = {
+                        "smirnoff": list(get_available_force_fields())
+                        + SMIRNOFFTemplateGenerator.INSTALLED_FORCEFIELDS,
+                        "antechamber": GAFFTemplateGenerator.INSTALLED_FORCEFIELDS,
+                    }[basis]
+                    if method not in allowed_methods:
+                        raise QCSpecificationError(
+                            f"The method {method} is not supported for the program {program} with "
+                            f"basis {basis}, please choose from {allowed_methods}"
+                        )
+                    method = method.lower()
+            else:
+                # torchani, xtb, and rdkit don't take a basis, so this is
+                # just a fixed lookup of allowed methods per program.
+                allowed_bases = (None,)
+                if basis not in allowed_bases:
+                    raise QCSpecificationError(
+                        f"The Basis {basis} is not supported for the program {program}, choose from {allowed_bases}"
+                    )
+
+                allowed_methods = {
+                    "torchani": ani_methods,
+                    "xtb": xtb_methods,
+                    "rdkit": rdkit_methods,
+                }[program.lower()]
+
+                method = method.lower()
+                if method not in allowed_methods:
+                    raise QCSpecificationError(
+                        f"The method {method} is not supported for the program {program} with "
+                        f"basis {basis}, please choose from {allowed_methods}"
+                    )
 
         if keywords is None:
             keywords = {}

--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -553,6 +553,7 @@ class QCSpec(ResultsConfig):
                         GAFFTemplateGenerator,
                         SMIRNOFFTemplateGenerator,
                     )
+
                     ommffs_installed = True
                 except ModuleNotFoundError:
                     ommffs_installed = False

--- a/openff/qcsubmit/common_structures.py
+++ b/openff/qcsubmit/common_structures.py
@@ -558,7 +558,6 @@ class QCSpec(ResultsConfig):
                 except ModuleNotFoundError:
                     ommffs_installed = False
 
-                method = method.lower()
                 if not ommffs_installed:
                     warnings.warn(
                         "openmmforcefields is not installed, so the requested OpenMM "
@@ -572,6 +571,9 @@ class QCSpec(ResultsConfig):
                         get_available_force_fields,
                     )
 
+                    # Force field names are filenames (or shorthand keys tied
+                    # 1:1 to filenames), which are case sensitive - unlike
+                    # `program`/`basis`, `method` must not be lowercased here.
                     allowed_methods = {
                         "smirnoff": list(get_available_force_fields())
                         + SMIRNOFFTemplateGenerator.INSTALLED_FORCEFIELDS,
@@ -582,7 +584,6 @@ class QCSpec(ResultsConfig):
                             f"The method {method} is not supported for the program {program} with "
                             f"basis {basis}, please choose from {allowed_methods}"
                         )
-                    method = method.lower()
             else:
                 # torchani, xtb, and rdkit don't take a basis, so this is
                 # just a fixed lookup of allowed methods per program.


### PR DESCRIPTION
[OpenMMForceFields 0.16.0](https://github.com/openmm/openmmforcefields/releases/#release-0.16.0) has a major update of SMIRNOFFTemplateGenerator which, changes several things. I've copied the releasenotes entry below:

----------------

Updates for openmmforcefields 0.16. When using the `openmm` program and `smirnoff` basis, QCSubmit passes `method` names to QCEngine, which passes them to openmm/openmmforcefields as if they were small molecule force fields.
* This PR removes some sanitization of force field names. Earlier versions of QCSubmit used to lowercase and strip the `.offxml` suffix from force fields before sending them to QCEngine (and thereby openmmforcefields). This is no longer the case, QCSubmit now passes SMIRNOFF `method` names to QCEngine unchanged. 
* The interpretation/application of SMIRNOFF force fields has changed in openmmforcefields 0.16. Notably, **openmmforcefields used to unconditionally strip `<Constraints>` from SMIRNOFF force fields and then re-apply constraints based on a separate argument (the `constraints` kwarg)**. As of openmmforcefields 0.16, the `<Constraints>` section is no longer stripped, and the final set of constraints applied is the UNION of those requested by the SMIRNOFF force field and those requested by the `constraints` kwarg passed to openmmforcefields.

This table shows the behavior of QCSubmit+QCEngine+OpenMMForceFields before and after these changes:

|                                   | OpenMMForceFields <0.16 and QCSubmit <=0.57.0                                | OpenMMForceFields >=0.16 and QCSubmit >0.57.0                              |
|-----------------------------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------|
| openff-X.Y.Z                      | Applies openff-X.Y.Z.offxml with <Constraints> section deleted               | Applies openff_unconstrained-X.Y.Z.offxml per SMIRNOFF spec (minor change) |
| openff-X.Y.Z.offxml               | QCSubmit deletes `.offxml` suffix so behavior is identical to row above      | Applies openff-X.Y.Z.offxml per SMIRNOFF spec (MAJOR change)               |
| openff_unconstrained-X.Y.Z        | Applies openff_unconstrained-X.Y.Z.offxml with <Constraints> section deleted | Raises an error                                                            |
| openff_unconstrained-X.Y.Z.offxml | QCSubmit deletes `.offxml` suffix so behavior is identical to row above      | Applies openff_unconstrained-X.Y.Z.offxml per SMIRNOFF spec (minor change) |

To the best of Jeff's knowledge, OpenFF [has not submitted](https://github.com/search?q=repo%3Aopenforcefield%2Fqca-dataset-submission+%22method%22%3A+%22openff+path%3A*json&type=code) any datasets to QCArchive that A) would encounter the "MAJOR change" case above or B) use the now-forbidden `openff_unconstrained-X.Y.Z` string, so all QC datasets should still be readable and computations reproducible (modulo water constraints). See https://github.com/openmm/openmmforcefields/releases/tag/0.16.0 for details on the openmmforcefields release.

